### PR TITLE
[SD-142] Check `blockchain-util` compliance with Serokell style guide [WIP]

### DIFF
--- a/snowdrop-block/src/Snowdrop/Block/Application.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Application.hs
@@ -54,12 +54,12 @@ applyBlock
 applyBlock = expandAndApplyBlock True
 
 expandAndApplyBlock
-    :: forall header payload rawPayload rawBlock undo blockRef e m
-    . ( MonadError e m
-      , Eq blockRef
-      , HasException e (BlockApplicationException blockRef)
-      , HasGetter rawBlock rawPayload
-      )
+    :: forall header payload rawPayload rawBlock undo blockRef e m .
+    ( MonadError e m
+    , Eq blockRef
+    , HasException e (BlockApplicationException blockRef)
+    , HasGetter rawBlock rawPayload
+    )
     => Bool
     -> OSParams
     -> BlkStateConfiguration header payload rawBlock rawPayload undo blockRef m
@@ -71,10 +71,10 @@ expandAndApplyBlock checkBIV osParams bsc rawBlk = do
 
 applyBlockImpl
     :: forall header payload rawPayload rawBlock undo blockRef e m .
-       ( MonadError e m
-       , Eq blockRef
-       , HasException e (BlockApplicationException blockRef)
-       )
+    ( MonadError e m
+    , Eq blockRef
+    , HasException e (BlockApplicationException blockRef)
+    )
     => Bool
     -> OSParams
     -> BlkStateConfiguration header payload rawBlock rawPayload undo blockRef m
@@ -105,20 +105,20 @@ applyBlockImpl checkBIV osParams (BlkStateConfiguration {..}) rawPayload blk@Blo
 -- 3. for each block in the fork: payload is applied, blund is stored and tip updated.
 tryApplyFork
     -- TODO `undo` is not Monoid, even for ChangeSet
-    :: forall header payload rawBlock rawPayload blockRef undo e m
-    . ( HasGetter rawBlock header
-      -- pva701: TODO ^ this constraint should be eliminated and
-      -- either expanding of headers should be made separately from blocks
-      -- or fork should be verified using scheme:
-      -- 1. rollback
-      -- 2. expand alt chain
-      -- 3. compare chains
-      -- 4. apply appropriate chain
-      , HasGetter rawBlock rawPayload
-      , Eq blockRef
-      , HasExceptions e [ForkVerificationException blockRef, BlockApplicationException blockRef]
-      , MonadError e m
-      )
+    :: forall header payload rawBlock rawPayload blockRef undo e m .
+    ( HasGetter rawBlock header
+    -- pva701: TODO ^ this constraint should be eliminated and
+    -- either expanding of headers should be made separately from blocks
+    -- or fork should be verified using scheme:
+    -- 1. rollback
+    -- 2. expand alt chain
+    -- 3. compare chains
+    -- 4. apply appropriate chain
+    , HasGetter rawBlock rawPayload
+    , Eq blockRef
+    , HasExceptions e [ForkVerificationException blockRef, BlockApplicationException blockRef]
+    , MonadError e m
+    )
     => BlkStateConfiguration header payload rawBlock rawPayload undo blockRef m
     -> OSParams
     -> OldestFirst NonEmpty rawBlock

--- a/snowdrop-block/src/Snowdrop/Block/Configuration.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Configuration.hs
@@ -24,8 +24,8 @@ instance Monoid (BlockIntegrityVerifier header payload) where
 -- validation of block sequence (chain) and come up with decision on whether
 -- the sequence shall be applied instead of currently adopted "best" chain.
 -- All methods presented in block validation configuration are stateless, all stateful checks shall
--- be performed as part of individual transaction validation (which is encapsulated in `bscApplyPayload`
--- method of block handling configuration `BlkStateConfiguration`.
+-- be performed as part of individual transaction validation (which is encapsulated in
+-- `bscApplyPayload` method of block handling configuration `BlkStateConfiguration`.
 data BlkConfiguration header payload blockRef = BlkConfiguration
     { bcBlockRef     :: header -> CurrentBlockRef blockRef
     -- ^ Get a block reference by given header.
@@ -68,19 +68,20 @@ data BlkConfiguration header payload blockRef = BlkConfiguration
     -- First block of proposed chain is assumed to have previous block reference to be an
     -- existing block in the currently adopted "best" chain (which is called an LCA of two chains).
     --
-    -- If the LCA block is more than `bcMaxForkDepth` blocks behind the most recent block of currently
-    -- adopted "best" chain, the proposed chain is considered invalid
+    -- If the LCA block is more than `bcMaxForkDepth` blocks behind the most recent block of
+    -- currently adopted "best" chain, the proposed chain is considered invalid
     -- (and won't be applied instead of currently adopted "best" chain).
     --
-    -- Parameter `bcMaxForkDepth` gives advise for implementation on how deep to inspect into currently
-    -- adopted "best" chain in order to compare currently adopted chain with proposed one.
+    -- Parameter `bcMaxForkDepth` gives advise for implementation on how deep to inspect into
+    -- currently adopted "best" chain in order to compare currently adopted chain with proposed one.
     -- Most of existing consensus protocols (including that behind such cryptocurrencies as Bitcoin,
-    -- Ethereum, Cardano) either directly or inherently provide possibility to define a particular value
-    -- for `bcMaxForkDepth`. In case, such definition is impossible to come up with, `maxBound @Int`
-    -- is advised to be used as value.
+    -- Ethereum, Cardano) either directly or inherently provide possibility to define a particular
+    -- value for `bcMaxForkDepth`. In case, such definition is impossible to come up with,
+    -- `maxBound @Int` is advised to be used as value.
     }
 
--- FIXME TODO actually it's valid to have `bfMaxForkDepth` forks, we might be terribly out of sync with network
+-- FIXME TODO actually it's valid to have `bfMaxForkDepth` forks,
+-- we might be terribly out of sync with network
 
 -- | Validate block container integrity:
 --      a. integrity of each block
@@ -96,9 +97,9 @@ blkSeqIsConsistent
     -> Bool
 blkSeqIsConsistent _ (OldestFirst []) = True
 blkSeqIsConsistent BlkConfiguration {..} (OldestFirst bdatas) =
-  and [ doValidate $ OldestFirst $ zip blks prevRefs
-      , unBIV bcBlkVerify $ unsafeLast blks -- validate last block
-      ]
+    and [ doValidate $ OldestFirst $ zip blks prevRefs
+        , unBIV bcBlkVerify $ unsafeLast blks -- validate last block
+        ]
   where
     blks = map getBlock bdatas
     prevRefs = unsafeTail (map getPrevRef blks)
@@ -119,7 +120,7 @@ blkSeqIsConsistent BlkConfiguration {..} (OldestFirst bdatas) =
     doValidate :: OldestFirst [] (Block header payload, Maybe blockRef) -> Bool
     doValidate (OldestFirst []) = True
     doValidate (OldestFirst ((b, prevRef):xs)) =
-      and [ unBIV bcBlkVerify b
-          , prevRef == getBlockRef b
-          , doValidate $ OldestFirst xs
-          ]
+        and [ unBIV bcBlkVerify b
+            , prevRef == getBlockRef b
+            , doValidate $ OldestFirst xs
+            ]

--- a/snowdrop-block/src/Snowdrop/Block/Fork.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Fork.hs
@@ -63,10 +63,10 @@ instance Buildable (ForkVerificationException blockRef) where
 --  returns `ApplyFork` iff evaluation results in `True`.
 verifyFork
     :: forall header payload rawBlock rawPayload undo blockRef e m .
-       ( MonadError e m
-       , Eq blockRef
-       , HasException e (ForkVerificationException blockRef)
-       )
+    ( MonadError e m
+    , Eq blockRef
+    , HasException e (ForkVerificationException blockRef)
+    )
     => BlkStateConfiguration header payload rawBlock rawPayload undo blockRef m
     -> OSParams
     -> OldestFirst NonEmpty header

--- a/snowdrop-block/src/Snowdrop/Block/OSParams.hs
+++ b/snowdrop-block/src/Snowdrop/Block/OSParams.hs
@@ -9,10 +9,8 @@ import           Data.Time.Clock (UTCTime)
 type Time = UTCTime
 
 data OSParams = OSParams
-  { currentTime :: Time
-  , startTime   :: Time
-  }
+    { currentTime :: Time
+    , startTime   :: Time
+    }
 
-newtype OSParamsBuilder = OSParamsBuilder
-  { unOSParamsBuilder :: Time -> OSParams
-  }
+newtype OSParamsBuilder = OSParamsBuilder { unOSParamsBuilder :: Time -> OSParams }

--- a/snowdrop-block/src/Snowdrop/Block/StateConfiguration.hs
+++ b/snowdrop-block/src/Snowdrop/Block/StateConfiguration.hs
@@ -9,7 +9,8 @@ import           Universum
 import           Snowdrop.Block.Configuration (BlkConfiguration (..))
 import           Snowdrop.Block.Types (Block (..), Blund (..))
 
--- | Block handling configuration. Contains methods for to perform handling of block sequence (chain):
+-- | Block handling configuration.
+-- Contains methods for to perform handling of block sequence (chain):
 --
 --  * load neccessary information from block storage,
 --  * perform structural validation (using methods from `bscConfig :: BlkConfiguration`),
@@ -19,9 +20,11 @@ import           Snowdrop.Block.Types (Block (..), Blund (..))
 --  block storage and state.
 --
 --  Block storage is used to store information required for block processing
---  (including tip block, currently adopted "best" chain), while state contains actual blockchain state
+--  (including tip block, currently adopted "best" chain),
+--  while state contains actual blockchain state
 --  as result of application of currently adopted "best" chain on initial blockchain state.
-data BlkStateConfiguration header payload rawBlock rawPayload undo blockRef m = BlkStateConfiguration
+data BlkStateConfiguration header payload rawBlock rawPayload undo blockRef m =
+  BlkStateConfiguration
     { bscApplyPayload :: payload -> m undo
     -- ^ Apply block payload to state. Note, that this method encapsulates validation of
     -- payload (and inidividual transactions contained in it) as well as actual application

--- a/snowdrop-block/src/Snowdrop/Block/Types.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Types.hs
@@ -25,18 +25,14 @@ class HasBlock header payload b where
 instance HasBlock header payload (Block header payload) where
     getBlock = identity
 
-data Blund header payload undo = Blund {
-    buBlock :: Block header payload
-  , buUndo  :: undo
-  } deriving (Eq, Ord, Show, Generic)
+data Blund header payload undo = Blund
+    { buBlock :: Block header payload
+    , buUndo  :: undo
+    } deriving (Eq, Ord, Show, Generic)
 
 instance HasBlock header payload (Blund header payload undo) where
     getBlock = getBlock . buBlock
 
-newtype CurrentBlockRef blockRef = CurrentBlockRef
-    { unCurrentBlockRef :: blockRef
-    }
+newtype CurrentBlockRef blockRef = CurrentBlockRef { unCurrentBlockRef :: blockRef }
 
-newtype PrevBlockRef blockRef = PrevBlockRef
-    { unPrevBlockRef :: (Maybe blockRef)
-    }
+newtype PrevBlockRef blockRef = PrevBlockRef { unPrevBlockRef :: (Maybe blockRef) }

--- a/snowdrop-core/src/Snowdrop/Core/BaseM.hs
+++ b/snowdrop-core/src/Snowdrop/Core/BaseM.hs
@@ -3,13 +3,13 @@
 {-# LANGUAGE Rank2Types          #-}
 
 module Snowdrop.Core.BaseM
-    (
-      BaseMConstraint
-    , BaseM (..)
-    , Concurrently (..)
-    , Race (..)
-    , Effectful (..)
-    ) where
+       (
+         BaseMConstraint
+       , BaseM (..)
+       , Concurrently (..)
+       , Race (..)
+       , Effectful (..)
+       ) where
 
 import           Universum hiding (log)
 
@@ -50,13 +50,19 @@ instance Race e m => Race e (ReaderT ctx m) where
 
 instance Concurrently m => Concurrently (ReaderT ctx m) where
     -- TODO implement other methods of type class as well
-    concurrentlySgImpl f ma mb = ReaderT $ \ctx -> concurrentlySgImpl f (runReaderT ma ctx) (runReaderT mb ctx)
+    concurrentlySgImpl f ma mb = ReaderT $
+        \ctx -> concurrentlySgImpl f (runReaderT ma ctx) (runReaderT mb ctx)
     concurrently ma mb = ReaderT $ \ctx -> concurrently (runReaderT ma ctx) (runReaderT mb ctx)
 
 instance Effectful eff m => Effectful eff (ReaderT ctx m) where
     effect = lift . effect
 
-type BaseMConstraint e eff ctx m = (Effectful eff m, Concurrently m, MonadReader ctx m, MonadError e m, Race e m, Log.MonadLogging m, Log.ModifyLogName m)
+type BaseMConstraint e eff ctx m = (Effectful eff m,
+                                    Concurrently m,
+                                    MonadReader ctx m,
+                                    MonadError e m, Race e m,
+                                    Log.MonadLogging m,
+                                    Log.ModifyLogName m)
 
 -- | Base execution monad.
 -- Notice, `BaseM` is not existential type, one would look like:

--- a/snowdrop-core/src/Snowdrop/Core/ChangeSet/ValueOp.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ChangeSet/ValueOp.hs
@@ -3,10 +3,10 @@
 {-# LANGUAGE DeriveTraversable #-}
 
 module Snowdrop.Core.ChangeSet.ValueOp
-    (
-      ValueOp (..)
-    , ValueOpEx (..)
-    ) where
+       (
+         ValueOp (..)
+       , ValueOpEx (..)
+       ) where
 
 import           Universum hiding (head, init, last)
 

--- a/snowdrop-core/src/Snowdrop/Core/ERoComp/Helpers.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERoComp/Helpers.hs
@@ -89,10 +89,10 @@ instance Buildable TxValidationException where
 -- If some value' couldn't be projected from corresponding value, the request will fail.
 querySet
     :: forall id id' value value' e ctx .
-       ( Ord id, Ord id'
-       , HasKeyValue id value id' value'
-       , HasException e StatePException
-       )
+    ( Ord id, Ord id'
+    , HasKeyValue id value id' value'
+    , HasException e StatePException
+    )
     => Set id' -> ERoComp e id value ctx (StateP id' value')
 querySet ids' =
     -- Choose needed ids from state, then try to project all values.
@@ -104,18 +104,18 @@ querySet ids' =
 -- TODO Not Exist shall be different error from getEx Left ()
 queryOne
     :: forall id id' value value' e ctx .
-       ( Ord id, Ord id'
-       , HasKeyValue id value id' value'
-       , HasException e StatePException
-       )
+    ( Ord id, Ord id'
+    , HasKeyValue id value id' value'
+    , HasException e StatePException
+    )
     => id' -> ERoComp e id value ctx (Maybe value')
 queryOne id' = M.lookup id' <$> querySet (S.singleton id')
 
 queryOneExists
     :: forall id id' value e ctx .
-       ( Ord id, Ord id'
-       , HasPrism id id'
-       )
+    ( Ord id, Ord id'
+    , HasPrism id id'
+    )
     => id' -> ERoComp e id value ctx Bool
 queryOneExists id' = not . M.null <$> query (S.singleton (inj id'))
 
@@ -162,9 +162,10 @@ getCAOrDefault (CAInitialized cA) = cA
 
 withModifiedAccumCtx
     :: forall e id value ctx a .
-       (HasException e (CSMappendException id),
-        HasLens ctx (ChgAccumCtx ctx),
-        Default (ChgAccum ctx))
+    ( HasException e (CSMappendException id)
+    , HasLens ctx (ChgAccumCtx ctx)
+    , Default (ChgAccum ctx)
+    )
     => ChangeSet id value
     -> ERoComp e id value ctx a
     -> ERoComp e id value ctx a
@@ -178,7 +179,7 @@ withModifiedAccumCtx chgSet comp = do
 
 initAccumCtx
     :: forall e id value ctx a .
-      (HasException e StatePException, HasLens ctx (ChgAccumCtx ctx))
+    (HasException e StatePException, HasLens ctx (ChgAccumCtx ctx))
     => ChgAccum ctx
     -> ERoComp e id value ctx a
     -> ERoComp e id value ctx a

--- a/snowdrop-core/src/Snowdrop/Core/ERoComp/Types.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERoComp/Types.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE DeriveFunctor #-}
 
 module Snowdrop.Core.ERoComp.Types
-    (
-      Prefix (..)
-    , IdSumPrefixed (..)
-    , StateR
-    , StateP
-    , FoldF (..)
-    , ERoComp
-    , ChgAccum
-    , ChgAccumCtx (..)
-    , DbAccess(..)
-    , ChgAccumModifier (..)
+       (
+         Prefix (..)
+       , IdSumPrefixed (..)
+       , StateR
+       , StateP
+       , FoldF (..)
+       , ERoComp
+       , ChgAccum
+       , ChgAccumCtx (..)
+       , DbAccess(..)
+       , ChgAccumModifier (..)
 
-    , foldFMappend
-    ) where
+       , foldFMappend
+       ) where
 
 import           Universum
 
@@ -23,8 +23,8 @@ import           Snowdrop.Core.BaseM (BaseM)
 import           Snowdrop.Core.ChangeSet (CSMappendException (..), ChangeSet (..), Undo)
 import           Snowdrop.Core.Prefix (IdSumPrefixed (..), Prefix (..))
 
-type StateR id = Set id          -- Request of state
-type StateP id value = Map id value -- Portion of state
+type StateR id = Set id             -- ^Request of state
+type StateP id value = Map id value -- ^Portion of state
 
 data FoldF a res = forall b. FoldF (b, a -> b -> b, b -> res)
 
@@ -32,7 +32,8 @@ instance Functor (FoldF a) where
     fmap f (FoldF (e, foldf, applier)) = FoldF (e, foldf, f . applier)
 
 foldFMappend :: (res -> res -> res) -> FoldF a res -> FoldF a res -> FoldF a res
-foldFMappend resMappend (FoldF (e1, f1, applier1)) (FoldF (e2, f2, applier2)) = FoldF (e, f, applier)
+foldFMappend resMappend (FoldF (e1, f1, applier1)) (FoldF (e2, f2, applier2))
+    = FoldF (e, f, applier)
   where
     e = (e1, e2)
     f a (b1, b2) = (f1 a b1, f2 a b2)
@@ -45,24 +46,26 @@ instance Semigroup res => Semigroup (FoldF a res) where
 -- | Change accum modifier object.
 -- Holds either change set or undo object which is to be applied to change accumulator.
 data ChgAccumModifier id value
-  = CAMChange
-    { camChg  :: ChangeSet id value
-    }
-  | CAMRevert
-    { camUndo :: Undo id value
-    }
+    = CAMChange { camChg  :: ChangeSet id value }
+    | CAMRevert { camUndo :: Undo id value }
 
 -- Datatype for access to database.
--- * mappend of two DbQuery executes as one DBQuery (as one Free iteration)
--- * mappend of DBIterator and x makes DBIterator execute one iteration of Free and require one more for x
+--
+--     * mappend of two DbQuery executes as one DBQuery (as one Free iteration)
+--     * mappend of DBIterator and x makes DBIterator execute one iteration of Free
+--     and require one more for x
+--
 -- It's essential to understand that unlike DBQuery,
 -- iterator always requires additional Free iteration.
 -- Given iterators are to be used rarely, this shall be ok.
 data DbAccess chgAccum id value res
-  = DbQuery (StateR id) (StateP id value -> res)
-  | DbIterator Prefix (FoldF (id, value) res)
-  | DbModifyAccum chgAccum (ChgAccumModifier id value) (Either (CSMappendException id) (chgAccum, Undo id value) -> res)
-  deriving (Functor)
+    = DbQuery (StateR id) (StateP id value -> res)
+    | DbIterator Prefix (FoldF (id, value) res)
+    | DbModifyAccum
+        chgAccum
+        (ChgAccumModifier id value)
+        (Either (CSMappendException id) (chgAccum, Undo id value) -> res)
+    deriving (Functor)
 
 -- | Reader computation which allows you to query for part of bigger state
 -- and build computation considering returned result.

--- a/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
@@ -1,10 +1,9 @@
 module Snowdrop.Core.ERwComp
-    (
-        ERwComp
-      , runERwComp
-      , modifyRwCompChgAccum
-      , liftERoComp
-    ) where
+       ( ERwComp
+       , runERwComp
+       , modifyRwCompChgAccum
+       , liftERoComp
+       ) where
 
 import           Universum
 

--- a/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
@@ -20,9 +20,9 @@ newtype ERwComp e id value ctx s a = ERwComp { unERwComp :: StateT s (ERoComp e 
 
 runERwComp
   :: forall e id value ctx s a.
-    ( HasException e StatePException
-    , HasGetter ctx (ChgAccumCtx ctx)
-    )
+  ( HasException e StatePException
+  , HasGetter ctx (ChgAccumCtx ctx)
+  )
   => ERwComp e id value ctx s a
   -> s
   -> ERoComp e id value ctx (a, s)

--- a/snowdrop-core/src/Snowdrop/Core/Expander.hs
+++ b/snowdrop-core/src/Snowdrop/Core/Expander.hs
@@ -24,7 +24,8 @@ import           Snowdrop.Core.Prefix (Prefix)
 import           Snowdrop.Core.Transaction (StateTxType)
 
 
-newtype Expander e id proof value ctx rawTx = Expander { unExpander :: Map StateTxType (PreExpanderSeq e id proof value ctx rawTx) }
+newtype Expander e id proof value ctx rawTx = Expander
+    { unExpander :: Map StateTxType (PreExpanderSeq e id proof value ctx rawTx) }
 
 -- | PreExpander allows you to convert one raw tx to StateTx.
 --  _inpSet_ is set of Prefixes which expander gets access to during computation.
@@ -37,13 +38,14 @@ data PreExpander e id proof value ctx rawTx = PreExpander
     , outSet      :: Set Prefix
     , expanderAct :: rawTx -> ERoComp e id value ctx (DiffChangeSet id value)
     }
+
 instance Contravariant (PreExpander e id proof value ctx) where
     contramap g (PreExpander s1 s2 f) = PreExpander s1 s2 (f . g)
 
 type PreExpandersSeq' e id proof value ctx rawTx = NonEmpty (PreExpander e id proof value ctx rawTx)
 
 newtype PreExpanderSeq e id proof value ctx rawTx
-  = PreExpanderSeq { getSeqExpanders :: PreExpandersSeq' e id proof value ctx rawTx }
+    = PreExpanderSeq { getSeqExpanders :: PreExpandersSeq' e id proof value ctx rawTx }
 
 instance Contravariant (PreExpanderSeq e id proof value ctx) where
     contramap g = PreExpanderSeq . NE.map (contramap g) . getSeqExpanders

--- a/snowdrop-core/src/Snowdrop/Core/Prefix.hs
+++ b/snowdrop-core/src/Snowdrop/Core/Prefix.hs
@@ -1,16 +1,18 @@
--- TODO: this module fixes cycle dep between Snowdrop.Core.ERoComp.Types and Snowdrop.Core.ChangeSet type
--- which is caused by that fact that dbAccess is defined using ChangeSet and Change set requires Prefix
--- instance. Should be moved to Transaction.hs according to the plan
+-- | TODO: this module fixes cycle dep between Snowdrop.Core.ERoComp.Types and
+-- Snowdrop.Core.ChangeSet type,
+-- which is caused by that fact that dbAccess is defined using ChangeSet and
+-- Change set requires Prefix -- instance. Should be moved to Transaction.hs according to the plan
 
 module Snowdrop.Core.Prefix
-    (
-      Prefix (..)
-    , IdSumPrefixed (..)
-    ) where
+       (
+         Prefix (..)
+       , IdSumPrefixed (..)
+       ) where
+
+import           Universum
 
 import qualified Data.Text.Buildable
 import           Formatting (bprint, int, (%))
-import           Universum
 
 import           Snowdrop.Util
 

--- a/snowdrop-core/src/Snowdrop/Core/Transaction.hs
+++ b/snowdrop-core/src/Snowdrop/Core/Transaction.hs
@@ -1,14 +1,14 @@
 module Snowdrop.Core.Transaction
-    ( SValue
-    , HasKeyValue
+       ( SValue
+       , HasKeyValue
 
-    , StateTxType (..)
-    , StateTx (..)
-    , PartialStateTx (..)
-    , mkPartialStateTx
+       , StateTxType (..)
+       , StateTx (..)
+       , PartialStateTx (..)
+       , mkPartialStateTx
 
-    , selectKeyValueCS
-    ) where
+       , selectKeyValueCS
+       ) where
 
 import           Universum
 

--- a/snowdrop-core/src/Snowdrop/Core/Validator/Basic.hs
+++ b/snowdrop-core/src/Snowdrop/Core/Validator/Basic.hs
@@ -73,9 +73,9 @@ instance Buildable RedundantIdException where
 
 redundantIdsPreValidator
     :: forall e id proof value ctx.
-       ( IdSumPrefixed id
-       , HasException e RedundantIdException
-       )
+    ( IdSumPrefixed id
+    , HasException e RedundantIdException
+    )
     => [Prefix]
     -> PreValidator e id proof value ctx
 redundantIdsPreValidator prefixes = PreValidator $ \statetx -> do

--- a/snowdrop-core/src/Snowdrop/Core/Validator/Types.hs
+++ b/snowdrop-core/src/Snowdrop/Core/Validator/Types.hs
@@ -21,8 +21,8 @@ import           Snowdrop.Util
 newtype PreValidator e id proof value ctx =
     PreValidator (StateTx id proof value -> ERoComp e id value ctx ())
 
-mkPreValidator ::
-       (StateTx id proof value -> ERoComp e id value ctx ())
+mkPreValidator
+    :: (StateTx id proof value -> ERoComp e id value ctx ())
     -> PreValidator e id proof value ctx
 mkPreValidator = PreValidator
 
@@ -38,8 +38,8 @@ instance Ord id => Monoid (PreValidator e id proof value ctx) where
     mempty = PreValidator $ const (pure ())
     mappend = (<>)
 
-mkValidator ::
-       Ord id
+mkValidator
+    :: Ord id
     => StateTxType
     -> [PreValidator e id proof value ctx]
     -> Validator e id proof value ctx

--- a/snowdrop-core/test/Test/Snowdrop/Core/ChangeSet.hs
+++ b/snowdrop-core/test/Test/Snowdrop/Core/ChangeSet.hs
@@ -18,7 +18,6 @@ import           Snowdrop.Util
 
 --  'Int' is used in types for simplicity.
 
-
 changeSetTests :: [TestTree]
 changeSetTests =
     [ testProperty "ValueOpEx Semigroup associativity law" prop_valueOpExAss

--- a/snowdrop-core/test/Test/Snowdrop/Core/Free.hs
+++ b/snowdrop-core/test/Test/Snowdrop/Core/Free.hs
@@ -46,19 +46,20 @@ where
 @q@ — number of query operations in the 'ERoComp's concatenation,
 @i@ — number of iterator operations in the 'ERoComp's concatenation,
 -}
+
 prop_ercLen :: Property
 prop_ercLen = property $ do
     finMap <- genIdValList
     erpc1 <- genEReaderComp finMap
     erpc2 <- genEReaderComp finMap
     let erpcRes  = erpc1 <> erpc2
-        cnts = liftA2 (,) (getOperNum erpc1) (getOperNum erpc2)
-        cntJ = getOperNum erpcRes
+        cnts     = liftA2 (,) (getOperNum erpc1) (getOperNum erpc2)
+        cntJ     = getOperNum erpcRes
     case (cnts, cntJ) of
-      (Left _, Left _) -> assert True
-      (Right (Counter q1 i1 m1, Counter q2 i2 m2), Right (Counter q i m)) ->
-          assert (i1 + i2 + m1 + m2 + q1 + q2 == i + q + m)
-      _ -> assert False
+        (Left _, Left _) -> assert True
+        (Right (Counter q1 i1 m1, Counter q2 i2 m2), Right (Counter q i m)) ->
+            assert (i1 + i2 + m1 + m2 + q1 + q2 == i + q + m)
+        _ -> assert False
     -- TODO adjust these tests for JoinExecT as it will be ready
     -- assert (i1 + i2 + max q1 q2 >= i + q)
 
@@ -117,7 +118,11 @@ genQueryOne = QueryOne <$> genT
 
 -- | Generates random 'Err'.
 genError :: MonadGen m => m Err
-genError = Gen.element [inj QueryProjectionFailed, inj IteratorProjectionFailed, inj (CSMappendException (TS "<generated exception>"))]
+genError = Gen.element
+    [ inj QueryProjectionFailed
+    , inj IteratorProjectionFailed
+    , inj (CSMappendException (TS "<generated exception>"))
+    ]
 
 -- | Generates 'ThrowError' command.
 genThrowError :: MonadGen m => m Command
@@ -150,7 +155,8 @@ genCommand res = Gen.frequency
 genCommands :: MonadGen m => [(Id, Value)] -> m [Command]
 genCommands = Gen.list lenRange . genCommand
 
-genEReaderComp :: Monad m
-               => [(Id, Value)]
-               -> PropertyT m (ERoComp Err Id Value (TestCtx Id Value) InterpetResult)
+genEReaderComp
+    :: Monad m
+    => [(Id, Value)]
+    -> PropertyT m (ERoComp Err Id Value (TestCtx Id Value) InterpetResult)
 genEReaderComp l = runCommands <$> forAll (genCommands l)

--- a/snowdrop-core/test/Test/Snowdrop/Core/Types.hs
+++ b/snowdrop-core/test/Test/Snowdrop/Core/Types.hs
@@ -31,10 +31,11 @@ import           Universum
 import           Control.Monad.Except (throwError)
 import           Data.Default (def)
 
+import           Test.Snowdrop.Core.Executor (Counter, TestCtx, countERoComp, runERoComp)
+
 import           Snowdrop.Core (CSMappendException (..), ERoComp, IdSumPrefixed (..), Prefix (..),
                                 SValue, StatePException (..), iteratorFor, queryOne, querySet)
 import           Snowdrop.Util
-import           Test.Snowdrop.Core.Executor (Counter, TestCtx, countERoComp, runERoComp)
 
 ----------------------------------------------------------------------------
 -- Types & functions
@@ -57,7 +58,7 @@ instance IdSumPrefixed Id where
 
 data Err = ErrCSM (CSMappendException Id)
          | ErrStateP StatePException
-  deriving (Eq, Show)
+    deriving (Eq, Show)
 
 deriveView withInj ''Err
 
@@ -187,8 +188,8 @@ getOperNum comp = runReader (countERoComp comp) def
 ----------------------------------------------------------------------------
 
 -- | Calculate the result of the given 'ERoComp' with provided map.
-getRes :: Map Id Value
-       -> ERoComp Err Id Value (TestCtx Id Value) InterpetResult
-       -> Either Err InterpetResult
+getRes
+    :: Map Id Value
+    -> ERoComp Err Id Value (TestCtx Id Value) InterpetResult
+    -> Either Err InterpetResult
 getRes mp er = runReader (runERoComp er) mp
-

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/AVLp.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/AVLp.hs
@@ -173,13 +173,14 @@ materialize initAVL = flip AVL.openAndM initAVL $ \case
 
 initAVLPureStorage
     :: forall k v m h .
-       ( MonadIO m
-       , MonadCatch m
-       , MonadThrow m
-       , KVConstraint k v
-       , AvlHashable h
-       , AVL.Hash h k v
-       , Serialisable (MapLayer h k v h))
+    ( MonadIO m
+    , MonadCatch m
+    , MonadThrow m
+    , KVConstraint k v
+    , AvlHashable h
+    , AVL.Hash h k v
+    , Serialisable (MapLayer h k v h)
+    )
     => Map k v -> m (AVLServerState h k)
 initAVLPureStorage (M.toList -> kvs) = reThrowAVLEx @k $ do
     (rootH, AVLPureStorage . unAVLCache -> st) <-
@@ -226,16 +227,16 @@ instance HasGetter (ClientTempState h k v n) (RootHash h) where
 
 avlClientDbActions
     :: forall k v m h n.
-       ( KVConstraint k v
-       , MonadIO m
-       , MonadCatch m
-       , AvlHashable h
-       , AVL.Hash h k v
-       , MonadIO n
-       , MonadCatch n
-       , RetrieveImpl (ReaderT (ClientTempState h k v n) m) h
-       , Serialisable (MapLayer h k v h)
-       )
+    ( KVConstraint k v
+    , MonadIO m
+    , MonadCatch m
+    , AvlHashable h
+    , AVL.Hash h k v
+    , MonadIO n
+    , MonadCatch n
+    , RetrieveImpl (ReaderT (ClientTempState h k v n) m) h
+    , Serialisable (MapLayer h k v h)
+    )
     => RetrieveF h n
     -> RootHash h
     -> n (ClientMode (AVL.Proof h k v) -> DbModifyActions (AVLChgAccum h k v) k v m ())

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/Composite.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/Composite.hs
@@ -23,15 +23,16 @@ data CompositeChgAccum chgAccumPrimary chgAccumSecondary ps = CompositeChgAccum
     , ccaSecondary :: chgAccumSecondary
     }
 
-instance (Default chgAccumPrimary, Default chgAccumSecondary) => Default (CompositeChgAccum chgAccumPrimary chgAccumSecondary ps) where
+instance (Default chgAccumPrimary, Default chgAccumSecondary)
+        => Default (CompositeChgAccum chgAccumPrimary chgAccumSecondary ps) where
     def = CompositeChgAccum def def
 
 constructCompositeActions
-  :: forall ps chgAccumPrimary chgAccumSecondary id value m .
-    (Reifies ps (Set Prefix), Ord id, MonadCatch m, IdSumPrefixed id)
-  => DbAccessActions chgAccumPrimary id value m
-  -> DbAccessActions chgAccumSecondary id value m
-  -> DbAccessActions (CompositeChgAccum chgAccumPrimary chgAccumSecondary ps) id value m
+    :: forall ps chgAccumPrimary chgAccumSecondary id value m .
+      (Reifies ps (Set Prefix), Ord id, MonadCatch m, IdSumPrefixed id)
+    => DbAccessActions chgAccumPrimary id value m
+    -> DbAccessActions chgAccumSecondary id value m
+    -> DbAccessActions (CompositeChgAccum chgAccumPrimary chgAccumSecondary ps) id value m
 constructCompositeActions dbaP dbaS =
     DbAccessActions cGetter cModifyAccum $ \(CompositeChgAccum caP caS) p ->
         bool (daaIter dbaS caS p) (daaIter dbaP caP p) $ p `S.member` prefixes
@@ -48,9 +49,9 @@ constructCompositeActions dbaP dbaS =
             CAMRevert (Undo cs sn) -> processCS (CAMRevert . flip Undo sn) cs
     mergeUndos (Undo csP snP) (Undo csS snS) =
       if BS.null snP || BS.null snS
-         then flip Undo (snP `BS.append` snS)
-               <$> (ExceptT $ pure $ csP `mappendChangeSet` csS)
-         else throwM $ DbApplyException "Both undo contain non-empty snapshot in composite actions"
+      then flip Undo (snP `BS.append` snS)
+           <$> (ExceptT $ pure $ csP `mappendChangeSet` csS)
+      else throwM $ DbApplyException "Both undo contain non-empty snapshot in composite actions"
     splitCS cs = (csP, csS)
       where
         csP = filterByPrefixPred (`S.member` prefixes) cs

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/Composite.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/Composite.hs
@@ -29,7 +29,7 @@ instance (Default chgAccumPrimary, Default chgAccumSecondary)
 
 constructCompositeActions
     :: forall ps chgAccumPrimary chgAccumSecondary id value m .
-      (Reifies ps (Set Prefix), Ord id, MonadCatch m, IdSumPrefixed id)
+    (Reifies ps (Set Prefix), Ord id, MonadCatch m, IdSumPrefixed id)
     => DbAccessActions chgAccumPrimary id value m
     -> DbAccessActions chgAccumSecondary id value m
     -> DbAccessActions (CompositeChgAccum chgAccumPrimary chgAccumSecondary ps) id value m

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/Simple.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/Simple.hs
@@ -27,45 +27,52 @@ import           Snowdrop.Util
 import           Snowdrop.Execution.DbActions.Types
 
 mappendStOrThrow
-  :: forall e id value m .
-     ( Monad m
-     , Ord id
-     , IdSumPrefixed id
-     , MonadState (SumChangeSet id value) m
-     , HasException e (CSMappendException id)
-     ) => ChangeSet id value -> m (Either e ())
-mappendStOrThrow chg = (flip modifySumChgSet chg) <$> get >>= either (pure . Left . inj) (\s -> put s $> Right ())
+    :: forall e id value m .
+       ( Monad m
+       , Ord id
+       , IdSumPrefixed id
+       , MonadState (SumChangeSet id value) m
+       , HasException e (CSMappendException id)
+       )
+    => ChangeSet id value
+    -> m (Either e ())
+mappendStOrThrow chg = (flip modifySumChgSet chg) <$> get >>=
+    either (pure . Left . inj) (\s -> put s $> Right ())
 
 -- | SumChangeSet holds some change set which is sum of several ChangeSet
 newtype SumChangeSet id value = SumChangeSet {unSumCS :: ChangeSet id value}
-  deriving Show
+    deriving Show
 
 instance Default (SumChangeSet id value) where
     def = SumChangeSet def
 
-modifySumChgSet   :: Ord id => SumChangeSet id value -> ChangeSet id value -> Either (CSMappendException id) (SumChangeSet id value)
+modifySumChgSet
+    :: Ord id
+    => SumChangeSet id value
+    -> ChangeSet id value
+    -> Either (CSMappendException id) (SumChangeSet id value)
 modifySumChgSet (SumChangeSet cs1) cs2 = SumChangeSet <$> mappendChangeSet cs1 cs2
 
-accumToDiff   :: SumChangeSet id value -> ChangeSet id value
+accumToDiff :: SumChangeSet id value -> ChangeSet id value
 accumToDiff = unSumCS
 
-queryAccum    :: Ord id => SumChangeSet id value -> StateR id -> (StateR id, StateP id value)
+queryAccum :: Ord id => SumChangeSet id value -> StateR id -> (StateR id, StateP id value)
 queryAccum (SumChangeSet accum) reqIds = (reqIds', resp)
   where
-    resp = changeSetToMap accum `M.intersection` toDummyMap reqIds
+    resp    = changeSetToMap accum `M.intersection` toDummyMap reqIds
     reqIds' = reqIds S.\\ M.keysSet (changeSet accum)
 
 queryAccumOne :: Ord id => SumChangeSet id value -> id -> Maybe (ValueOp value)
 queryAccumOne (SumChangeSet (ChangeSet csm)) = flip M.lookup csm
 
-getNewKeys    :: IdSumPrefixed id => SumChangeSet id value -> Prefix -> Map id value
+getNewKeys :: IdSumPrefixed id => SumChangeSet id value -> Prefix -> Map id value
 getNewKeys (SumChangeSet cs) p = csNew $ filterByPrefix p cs
 
 sumChangeSetDBA
-  :: forall id value m . (IdSumPrefixed id, Ord id, MonadCatch m)
-  => (StateR id -> m (StateP id value))
-  -> (forall b. Prefix -> b -> ((id, value) -> b -> b) -> m b)
-  -> DbAccessActions (SumChangeSet id value) id value m
+    :: forall id value m . (IdSumPrefixed id, Ord id, MonadCatch m)
+    => (StateR id -> m (StateP id value))
+    -> (forall b. Prefix -> b -> ((id, value) -> b -> b) -> m b)
+    -> DbAccessActions (SumChangeSet id value) id value m
 sumChangeSetDBA getImpl iterImpl =
     DbAccessActions
       getter
@@ -82,12 +89,13 @@ sumChangeSetDBA getImpl iterImpl =
           (liftA2 (,) $ accum `modifySumChgSet` cs')
             <$> runExceptT (flip Undo BS.empty <$> computeUndo accum cs')
 
-    computeUndo :: SumChangeSet id value -> ChangeSet id value -> ExceptT (CSMappendException id) m (ChangeSet id value)
+    computeUndo
+        :: SumChangeSet id value
+        -> ChangeSet id value
+        -> ExceptT (CSMappendException id) m (ChangeSet id value)
     computeUndo ca (ChangeSet cs) = do
         vals <- lift $ getter ca (M.keysSet cs)
-        let
-          processOne m (k, valueop) =
-            case (valueop, k `M.lookup` vals) of
+        let processOne m (k, valueop) = case (valueop, k `M.lookup` vals) of
               (New _, Nothing)      -> pure $ M.insert k Rem m
               (Upd _, Just v0)      -> pure $ M.insert k (Upd v0) m
               (NotExisted, Nothing) -> pure $ M.insert k NotExisted m
@@ -96,9 +104,13 @@ sumChangeSetDBA getImpl iterImpl =
         ChangeSet <$> foldM processOne mempty (M.toList cs)
 
 chgAccumIter
-  :: (IdSumPrefixed id, Ord id, Applicative m)
-  => (Prefix -> b -> ((id, value) -> b -> b) -> m b)
-  -> SumChangeSet id value -> Prefix -> b -> ((id, value) -> b -> b) -> m b
+    :: (IdSumPrefixed id, Ord id, Applicative m)
+    => (Prefix -> b -> ((id, value) -> b -> b) -> m b)
+    -> SumChangeSet id value
+    -> Prefix
+    -> b
+    -> ((id, value) -> b -> b)
+    -> m b
 chgAccumIter iter accum prefix initB foldF =
     let newKeysB = M.foldrWithKey (\i v r -> foldF (i, v) r) initB $ getNewKeys accum prefix
         newFoldF (i, val) b = case queryAccumOne accum i of
@@ -111,9 +123,13 @@ chgAccumIter iter accum prefix initB foldF =
 
 
 chgAccumGetter
-  :: (IdSumPrefixed id, Ord id, Applicative m)
-  => (StateR id -> m (StateP id value)) -> SumChangeSet id value -> StateR id -> m (StateP id value)
-chgAccumGetter getter accum reqIds = bool (unionStateP resp <$> getter reqIds') (pure resp) (null reqIds')
+    :: (IdSumPrefixed id, Ord id, Applicative m)
+    => (StateR id -> m (StateP id value))
+    -> SumChangeSet id value
+    -> StateR id
+    -> m (StateP id value)
+chgAccumGetter getter accum reqIds =
+    bool (unionStateP resp <$> getter reqIds') (pure resp) (null reqIds')
   where
     (reqIds', resp) = queryAccum accum reqIds
     unionStateP = M.unionWith (error "chgAccumGetter: unexpected overlap of keys")

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/Simple.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/Simple.hs
@@ -28,12 +28,12 @@ import           Snowdrop.Execution.DbActions.Types
 
 mappendStOrThrow
     :: forall e id value m .
-       ( Monad m
-       , Ord id
-       , IdSumPrefixed id
-       , MonadState (SumChangeSet id value) m
-       , HasException e (CSMappendException id)
-       )
+    ( Monad m
+    , Ord id
+    , IdSumPrefixed id
+    , MonadState (SumChangeSet id value) m
+    , HasException e (CSMappendException id)
+    )
     => ChangeSet id value
     -> m (Either e ())
 mappendStOrThrow chg = (flip modifySumChgSet chg) <$> get >>=

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/Types.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/Types.hs
@@ -21,7 +21,9 @@ import           Snowdrop.Core (CSMappendException (..), ChgAccumModifier, Prefi
 data DbAccessActions chgAccum id value m = DbAccessActions
     { daaGetter      :: chgAccum -> StateR id -> m (StateP id value)
       -- ^ Retrieves values corresponding to specified keys (doesn't modify the state)
-    , daaModifyAccum :: chgAccum -> ChgAccumModifier id value -> m (Either (CSMappendException id) (chgAccum, Undo id value))
+    , daaModifyAccum :: chgAccum
+                     -> ChgAccumModifier id value
+                     -> m (Either (CSMappendException id) (chgAccum, Undo id value))
       -- ^ Modify change accumulater with specified change set (doesn't modify the state)
     , daaIter        :: forall b . chgAccum -> Prefix -> b -> ((id, value) -> b -> b) -> m b
       -- ^ Iterate through keys with specified prefix (doesn't modify the state)
@@ -34,11 +36,11 @@ data DbModifyActions chgAccum id value m proof = DbModifyActions
     }
 
 data DbActionsException
-  = DbApplyException Text
-  | DbWrongIdQuery Text
-  | DbWrongPrefixIter Text
-  | DbProtocolError Text
-  deriving Show
+    = DbApplyException Text
+    | DbWrongIdQuery Text
+    | DbWrongPrefixIter Text
+    | DbProtocolError Text
+    deriving Show
 
 instance Exception DbActionsException
 
@@ -53,5 +55,5 @@ instance Buildable DbActionsException where
 data RememberForProof = RememberForProof { unRememberForProof :: Bool }
 
 data ClientMode proof
-  = ProofMode { cmProof :: proof }
-  | RemoteMode
+    = ProofMode { cmProof :: proof }
+    | RemoteMode

--- a/snowdrop-execution/src/Snowdrop/Execution/Expand.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/Expand.hs
@@ -87,13 +87,13 @@ instance Buildable ExpandException where
 -- E_i tx2 to the second and so on and so forth.
 expandRawTxs
     :: forall rawTx e id proof value ctx .
-       ( Ord id
-       , IdSumPrefixed id
-       , HasExceptions e [CSMappendException id, RestrictionInOutException]
-       , HasLens ctx (ChgAccumCtx ctx)
-       , Default (ChgAccum ctx)
-       , HasLens ctx RestrictCtx
-       )
+    ( Ord id
+    , IdSumPrefixed id
+    , HasExceptions e [CSMappendException id, RestrictionInOutException]
+    , HasLens ctx (ChgAccumCtx ctx)
+    , Default (ChgAccum ctx)
+    , HasLens ctx RestrictCtx
+    )
     => (rawTx -> (StateTxType, proof))
     -> [rawTx]
     -> PreExpanderSeq e id proof value ctx rawTx
@@ -202,13 +202,13 @@ expandUnionRawTxs mkProof expander txs = do
 
 runSeqExpandersSequentially
     :: forall rawTx e id proof value ctx .
-       ( IdSumPrefixed id
-       , Ord id
-       , HasExceptions e [CSMappendException id, RestrictionInOutException]
-       , HasLens ctx (ChgAccumCtx ctx)
-       , HasLens ctx RestrictCtx
-       , Default (ChgAccum ctx)
-       )
+    ( IdSumPrefixed id
+    , Ord id
+    , HasExceptions e [CSMappendException id, RestrictionInOutException]
+    , HasLens ctx (ChgAccumCtx ctx)
+    , HasLens ctx RestrictCtx
+    , Default (ChgAccum ctx)
+    )
     => (rawTx -> (StateTxType, proof))
     -> [(rawTx, PreExpandersSeq' e id proof value ctx rawTx)]
     -> ERoComp e id value ctx [StateTx id proof value]

--- a/snowdrop-execution/src/Snowdrop/Execution/Expand.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/Expand.hs
@@ -28,10 +28,11 @@ import           Snowdrop.Execution.Restrict (RestrictCtx, RestrictionInOutExcep
                                               restrictDbAccess)
 import           Snowdrop.Util
 
--- RawTxStates holds all needed states to compute state for the next expander.
+-- | RawTxStates holds all needed states to compute state for the next expander.
 data RawTxState id value = RawTxState
-    { rtsSum      :: SumChangeSet id value -- mappends of all previous expanders for this tx
-    , rtsExpState :: SumChangeSet id value -- mappends of all previous expanders for all previous txs
+    { rtsSum      :: SumChangeSet id value -- ^ mappends of all previous expanders for this tx
+    , rtsExpState :: SumChangeSet id value -- ^ mappends of all previous expanders for all
+                                           -- previous txs
     }
 
 data ExpandException
@@ -40,7 +41,8 @@ data ExpandException
 
 instance Buildable ExpandException where
     build = \case
-        NoExpanderForTransactionType stateTxType -> bprint ("No expander found for transaction type"%build)  stateTxType
+        NoExpanderForTransactionType stateTxType ->
+            bprint ("No expander found for transaction type"%build) stateTxType
 
 -- | We have severals txs to expand using sequence of expanders.
 -- We may run them *sequentually*: sequence of expanders is run on each tx.
@@ -58,7 +60,8 @@ instance Buildable ExpandException where
 -- Running in parallel isn't always possible.
 -- It's possible only when expanding of a transaction doesn't
 -- depend on application expanded StateTx of previous transactions.
--- (*) Formally: when (inpSet E_i) ∩ (outSet E_j) = ∅ for j >= i, for 1 <= i, j <= numbers of expanders.
+-- (*) Formally:
+-- when (inpSet E_i) ∩ (outSet E_j) = ∅ for j >= i, for 1 <= i, j <= numbers of expanders.
 -- If it isn't satisfied then running E_j on tx_k may produce changes
 -- which affect expanding of E_i on tx_{k+1}. Basically we get data dependency
 -- and we aren't able to run expanders in parallel.
@@ -73,22 +76,24 @@ instance Buildable ExpandException where
 --   (E1 tx2 `mappend` E2 tx2 ... `mappend` En tx2) `mappend` ...
 --   (E1 tx_{k-1}             ... `mappend` E_n tx_{k-1}).
 -- How it looks when expanding is performing sequentially.
--- But for expanders holds (*) so we just can remove from consideration expanding of E_j where j >= i.
+-- But for expanders holds (*) so we just can remove from consideration
+-- expanding of E_j where j >= i.
 -- So we get
 --   (E1 tx1 `mappend` E2 tx1 ... `mappend` E_{i-1} tx1) `mappend`
 --   (E1 tx2 `mappend` E2 tx2 ... `mappend` E_{i-1} tx2) `mappend` ...
 --   (E1 tx_{k-1}             ... `mappend` E_{i-1} tx_{k-1}).
 -- How can it be recomputed for E_{i+1} tx_k?
--- We can just mappend E_i tx1 to the first parentheses, E_i tx2 to the second and so on and so forth.
+-- We can just mappend E_i tx1 to the first parentheses,
+-- E_i tx2 to the second and so on and so forth.
 expandRawTxs
-  :: forall rawTx e id proof value ctx .
-    ( Ord id
-    , IdSumPrefixed id
-    , HasExceptions e [CSMappendException id, RestrictionInOutException]
-    , HasLens ctx (ChgAccumCtx ctx)
-    , Default (ChgAccum ctx)
-    , HasLens ctx RestrictCtx
-    )
+    :: forall rawTx e id proof value ctx .
+       ( Ord id
+       , IdSumPrefixed id
+       , HasExceptions e [CSMappendException id, RestrictionInOutException]
+       , HasLens ctx (ChgAccumCtx ctx)
+       , Default (ChgAccum ctx)
+       , HasLens ctx RestrictCtx
+       )
     => (rawTx -> (StateTxType, proof))
     -> [rawTx]
     -> PreExpanderSeq e id proof value ctx rawTx
@@ -96,18 +101,23 @@ expandRawTxs
 expandRawTxs mkProof rawTxs (getSeqExpanders -> expander) =
     -- Check whether expanding can be run in parallel.
     if checkParallelization expander then
-        runExpandersInParallel (squashSeqExpanders expander) $ take (length rawTxs) $ repeat (RawTxState def def)
+        runExpandersInParallel (squashSeqExpanders expander) $
+            take (length rawTxs) $ repeat (RawTxState def def)
     else
         runSeqExpandersSequentially mkProof (zip rawTxs $ repeat expander)
   where
-    intersectsInpOut :: PreExpander e id proof value ctx rawTx -> PreExpander e id proof value ctx rawTx -> Bool
+    intersectsInpOut
+        :: PreExpander e id proof value ctx rawTx
+        -> PreExpander e id proof value ctx rawTx
+        -> Bool
     intersectsInpOut e1 e2 = not $ S.null $ S.intersection (inpSet e1) (outSet e2)
 
     -- Check that (inpSet E_i) ∩ (outSet E_j) = ∅ for j >= i, for 0 <= i, j < numbers of expanders.
     checkParallelization :: PreExpandersSeq' e id proof value ctx rawTx -> Bool
     checkParallelization (x :| []) = intersectsInpOut x x
     checkParallelization (x :| xs) =
-        if any (intersectsInpOut x) (x:xs) then False
+        if any (intersectsInpOut x) (x:xs)
+        then False
         else checkParallelization $ NE.fromList xs
 
     runExpandersInParallel
@@ -115,19 +125,21 @@ expandRawTxs mkProof rawTxs (getSeqExpanders -> expander) =
         -> [RawTxState id value]
         -> ERoComp e id value ctx [StateTx id proof value]
     runExpandersInParallel (ex:|xs) prevRawTxStates =
-      runExpanderOnAllTxsParallel >>= \stxSums ->
+        runExpanderOnAllTxsParallel >>= \stxSums ->
             -- We should apply portion of expanded data for next expander.
             -- So basically for each tx we accumulate all previous expanded changesets
             -- to be able run the next expander correctly.
             case xs of
-              (ex1:xs1) ->
-                  case computeAccumulatedCSs stxSums of
+                (ex1:xs1) -> case computeAccumulatedCSs stxSums of
                     Left csex    -> throwLocalError csex
                     Right accCSs -> runExpandersInParallel (ex1 :| xs1) accCSs
-              _ -> pure $ map (\(rtx, stxCS) -> (uncurry StateTx) (mkProof rtx) (accumToDiff stxCS)) . safeZip rawTxs $ stxSums
+                _ -> pure $ map
+                              (\(rtx, stxCS) -> (uncurry StateTx) (mkProof rtx) (accumToDiff stxCS))
+                              . safeZip rawTxs $ stxSums
 
       where
-        -- Accumulate changeset for previous step with changes from previous txs expanded by current expander.
+        -- | Accumulate changeset for previous step with changes from previous txs
+        -- expanded by current expander.
         computeAccumulatedCSs
             :: [SumChangeSet id value]
             -> Either (CSMappendException id) [RawTxState id value]
@@ -136,8 +148,8 @@ expandRawTxs mkProof rawTxs (getSeqExpanders -> expander) =
         accM :: [RawTxState id value]
              -> SumChangeSet id value
              -> Either (CSMappendException id) [RawTxState id value]
-        accM [] sumCS
-            = Right $ [RawTxState sumCS def] -- TODO in case when init state not empty, pass this init state to second argument
+        accM [] sumCS = Right $ [RawTxState sumCS def] -- TODO in case when init state not empty,
+                                                       -- pass this init state to second argument
         accM a@(sumSt:_) newRtsSum = do
             newRtsExpState <- rtsExpState sumSt `modifySumChgSet` accumToDiff (rtsSum sumSt)
             pure $ RawTxState newRtsSum newRtsExpState : a
@@ -156,11 +168,12 @@ expandRawTxs mkProof rawTxs (getSeqExpanders -> expander) =
 
         safeZip :: [a] -> [b] -> [(a, b)]
         safeZip as bs =
-            if length as /= length bs then error "safeZip: length of list isn't same"
+            if length as /= length bs
+            then error "safeZip: length of list isn't same"
             else zip as bs
 
 expandUnionRawTxs
-  :: forall rawTx e id proof value ctx .
+    :: forall rawTx e id proof value ctx .
     ( Ord id
     , IdSumPrefixed id
     , HasExceptions e [CSMappendException id, RestrictionInOutException, ExpandException]
@@ -176,38 +189,46 @@ expandUnionRawTxs mkProof expander txs = do
     expanders <- traverse toTxWithExp txs
     runSeqExpandersSequentially mkProof expanders
       where
-        toTxWithExp :: rawTx -> ERoComp e id value ctx (rawTx, (PreExpandersSeq' e id proof value ctx rawTx))
+        toTxWithExp
+            :: rawTx
+            -> ERoComp e id value ctx (rawTx, (PreExpandersSeq' e id proof value ctx rawTx))
         toTxWithExp tx = let
             (stateTxType, _) = mkProof tx
           in do
-            seqExpanders <- maybeThrowLocal (NoExpanderForTransactionType stateTxType) (M.lookup stateTxType (unExpander expander))
+            seqExpanders <- maybeThrowLocal
+                              (NoExpanderForTransactionType stateTxType)
+                              (M.lookup stateTxType (unExpander expander))
             pure (tx, getSeqExpanders seqExpanders)
 
 runSeqExpandersSequentially
-  :: forall rawTx e id proof value ctx .
-    ( IdSumPrefixed id
-    , Ord id
-    , HasExceptions e [CSMappendException id, RestrictionInOutException]
-    , HasLens ctx (ChgAccumCtx ctx)
-    , HasLens ctx RestrictCtx
-    , Default (ChgAccum ctx)
-    )
+    :: forall rawTx e id proof value ctx .
+       ( IdSumPrefixed id
+       , Ord id
+       , HasExceptions e [CSMappendException id, RestrictionInOutException]
+       , HasLens ctx (ChgAccumCtx ctx)
+       , HasLens ctx RestrictCtx
+       , Default (ChgAccum ctx)
+       )
     => (rawTx -> (StateTxType, proof))
     -> [(rawTx, PreExpandersSeq' e id proof value ctx rawTx)]
     -> ERoComp e id value ctx [StateTx id proof value]
 runSeqExpandersSequentially mkProof txWithExp =
     reverse <$> evalStateT (foldM runExps [] txWithExp) def
   where
-    runExps :: [StateTx id proof value]
-            -> (rawTx, PreExpandersSeq' e id proof value ctx rawTx)
-            -> StateT (SumChangeSet id value) (ERoComp e id value ctx) [StateTx id proof value]
+    runExps
+        :: [StateTx id proof value]
+        -> (rawTx, PreExpandersSeq' e id proof value ctx rawTx)
+        -> StateT (SumChangeSet id value) (ERoComp e id value ctx) [StateTx id proof value]
     runExps txs rtx = do
         chgAcc <- get
         stx <- lift $ withModifiedAccumCtx (accumToDiff chgAcc) (runSeqExpandersForTx rtx)
         mappendStOrThrow @e (txBody stx) $> (stx : txs)
 
-    runSeqExpandersForTx :: (rawTx, PreExpandersSeq' e id proof value ctx rawTx) -> ERoComp e id value ctx (StateTx id proof value)
-    runSeqExpandersForTx (tx, sexp) = (uncurry StateTx) (mkProof tx) . accumToDiff <$> foldM (applyExpander tx) def sexp
+    runSeqExpandersForTx
+        :: (rawTx, PreExpandersSeq' e id proof value ctx rawTx)
+        -> ERoComp e id value ctx (StateTx id proof value)
+    runSeqExpandersForTx (tx, sexp) =
+        (uncurry StateTx) (mkProof tx) . accumToDiff <$> foldM (applyExpander tx) def sexp
 
 applyExpander
     :: ( IdSumPrefixed id
@@ -239,17 +260,21 @@ mappendExpander a b = PreExpander
     act
   where
     act rtx = do
-        resList :: [DiffChangeSet id value] <- fmap one (expanderAct a rtx) <> fmap one (expanderAct b rtx)
+        resList :: [DiffChangeSet id value] <- fmap one (expanderAct a rtx) <>
+                                               fmap one (expanderAct b rtx)
         case resList of
-            (DiffChangeSet l):(DiffChangeSet r):[] -> eitherThrow $ DiffChangeSet <$> first inj (l `mappendChangeSet` r)
+            (DiffChangeSet l):(DiffChangeSet r):[] ->
+                eitherThrow $ DiffChangeSet <$> first inj (l `mappendChangeSet` r)
             _      -> error "impossibro"
 
 squashSeqExpanders
     :: (Ord id, HasException e (CSMappendException id))
-    => PreExpandersSeq' e id proof value ctx rawTx -> PreExpandersSeq' e id proof value ctx rawTx
+    => PreExpandersSeq' e id proof value ctx rawTx
+    -> PreExpandersSeq' e id proof value ctx rawTx
 squashSeqExpanders (x:|[]) = one x
 squashSeqExpanders (a:|b:xs) =
-    if inpOutIntersection then NE.cons a (squashSeqExpanders (b :| xs))
+    if inpOutIntersection
+    then NE.cons a (squashSeqExpanders (b :| xs))
     else squashSeqExpanders (a `mappendExpander` b :| xs)
   where
     inpOutIntersection = not $ S.null $ S.intersection (outSet a) (inpSet b)

--- a/snowdrop-execution/src/Snowdrop/Execution/IOExecutor.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/IOExecutor.hs
@@ -78,8 +78,8 @@ instance (Show e, Typeable e) => Race e (BaseMIO e eff ctx) where
 
 runBaseMIO
     :: forall e eff ctx a .
-       (Show e, Typeable e, HasGetter ctx (BaseMIOExec eff ctx),
-       (Loot.HasLens Log.LoggingIO ctx Log.LoggingIO))
+    (Show e, Typeable e, HasGetter ctx (BaseMIOExec eff ctx),
+    (Loot.HasLens Log.LoggingIO ctx Log.LoggingIO))
     => BaseM e eff ctx a
     -> ctx
     -> ExecM a
@@ -123,13 +123,13 @@ instance HasGetter (IOCtx chgAccum id value) (ChgAccumCtx (IOCtx chgAccum id val
 
 runERoCompIO
     :: forall e id value chgAccum a ctx m.
-       ( Show e
-       , Typeable e
-       , Default chgAccum
-       , MonadIO m
-       , MonadReader ctx m
-       , HasLens' ctx Log.LoggingIO
-       )
+    ( Show e
+    , Typeable e
+    , Default chgAccum
+    , MonadIO m
+    , MonadReader ctx m
+    , HasLens' ctx Log.LoggingIO
+    )
     => DbAccessActions chgAccum id value ExecM
     -> Maybe chgAccum
     -> ERoComp e id value (IOCtx chgAccum id value) a

--- a/snowdrop-execution/src/Snowdrop/Execution/IOExecutor.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/IOExecutor.hs
@@ -2,30 +2,32 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Snowdrop.Execution.IOExecutor
-    (
-      runBaseMIO
-    , BaseMIOExec (..)
-    , BaseMIO
-    , BaseMException (..)
-    , IOCtx (..)
-    , runERwCompIO
-    , runERoCompIO
-    -- * Lens
-    , ctxChgAccum
-    , ctxExec
-    , ctxRestrict
-    ) where
+       (
+         runBaseMIO
+       , BaseMIOExec (..)
+       , BaseMIO
+       , BaseMException (..)
+       , IOCtx (..)
+       , runERwCompIO
+       , runERoCompIO
+       -- * Lens
+       , ctxChgAccum
+       , ctxExec
+       , ctxRestrict
+       ) where
+
+import           Universum
 
 import qualified Control.Concurrent.Async.Lifted as Async
 import           Control.Lens (makeLenses)
 import           Control.Monad.Except (MonadError (..))
 import           Data.Default (Default (def))
 import qualified Data.Text.Buildable as Buildable
-import           Loot.Base.HasLens (HasLens', lensOf)
-import           Universum
 
+import           Loot.Base.HasLens (HasLens', lensOf)
 import qualified Loot.Base.HasLens as Loot
 import qualified Loot.Log.Rio as Rio
+
 import           Snowdrop.Core (BaseM (..), ChgAccum, ChgAccumCtx (..), Concurrently (..),
                                 DbAccess (..), ERoComp, ERwComp, Effectful (..), FoldF (..),
                                 Race (..), StatePException, getCAOrDefault, runERwComp)
@@ -48,38 +50,39 @@ instance (Show e, Typeable e) => Exception (BaseMException e)
 newtype BaseMIO e (eff :: * -> *) ctx a = BaseMIO { unBaseMIO :: ReaderT ctx ExecM a }
     deriving (Functor, Applicative, Monad, MonadReader ctx, MonadIO)
 
-instance (Loot.HasLens' ctx Log.LoggingIO)
-    => Log.MonadLogging (BaseMIO e eff ctx) where
-        log = Rio.defaultLog
-        logName = Rio.defaultLogName
+instance (Loot.HasLens' ctx Log.LoggingIO) => Log.MonadLogging (BaseMIO e eff ctx) where
+    log = Rio.defaultLog
+    logName = Rio.defaultLogName
 
-instance (Loot.HasLens' ctx Log.LoggingIO)
-    => Log.ModifyLogName (BaseMIO e eff ctx) where
-        modifyLogNameSel = Rio.defaultModifyLogNameSel
+instance (Loot.HasLens' ctx Log.LoggingIO) => Log.ModifyLogName (BaseMIO e eff ctx) where
+    modifyLogNameSel = Rio.defaultModifyLogNameSel
 
 instance HasGetter ctx (BaseMIOExec eff ctx) => Effectful eff (BaseMIO e eff ctx) where
     effect eff = BaseMIO $ ReaderT $ \ctx -> unBaseMIOExec (gett ctx) ctx eff
 
 instance Concurrently (BaseMIO e eff ctx) where
     concurrently ma mb = BaseMIO $ ReaderT $ \ctx ->
-      Async.concurrently
+        Async.concurrently
           (runReaderT (unBaseMIO @e ma) ctx)
           (runReaderT (unBaseMIO @e mb) ctx)
 
 instance (Show e, Typeable e) => MonadError e (BaseMIO e eff ctx) where
     throwError e = BaseMIO $ throwM $ BaseMException e
-    catchError (BaseMIO ma) handler = BaseMIO $ ma `catch` (\(BaseMException e) -> unBaseMIO $ handler e)
+    catchError (BaseMIO ma) handler = BaseMIO $
+        ma `catch` (\(BaseMException e) -> unBaseMIO $ handler e)
 
 instance (Show e, Typeable e) => Race e (BaseMIO e eff ctx) where
     race ma mb = BaseMIO $ ReaderT $ \ctx ->
-      Async.race (runReaderT (unBaseMIO @e ma) ctx)
-                 (runReaderT (unBaseMIO @e mb) ctx)
+        Async.race (runReaderT (unBaseMIO @e ma) ctx)
+                   (runReaderT (unBaseMIO @e mb) ctx)
 
 runBaseMIO
-  :: forall e eff ctx a .
-    (Show e, Typeable e, HasGetter ctx (BaseMIOExec eff ctx),
-    (Loot.HasLens Log.LoggingIO ctx Log.LoggingIO))
-  => BaseM e eff ctx a -> ctx -> ExecM a
+    :: forall e eff ctx a .
+       (Show e, Typeable e, HasGetter ctx (BaseMIOExec eff ctx),
+       (Loot.HasLens Log.LoggingIO ctx Log.LoggingIO))
+    => BaseM e eff ctx a
+    -> ctx
+    -> ExecM a
 runBaseMIO bm ctx = runReaderT (unBaseMIO @e @eff $ unBaseM bm) ctx
 
 data IOCtx chgAccum id value = IOCtx
@@ -102,10 +105,14 @@ instance HasLens (IOCtx chgAccum id value) RestrictCtx where
 instance HasGetter (IOCtx chgAccum id value) RestrictCtx where
     gett = _ctxRestrict
 
-instance HasLens (IOCtx chgAccum id value) (BaseMIOExec (DbAccess chgAccum id value) (IOCtx chgAccum id value)) where
+instance HasLens
+           (IOCtx chgAccum id value)
+           (BaseMIOExec (DbAccess chgAccum id value) (IOCtx chgAccum id value)) where
     sett ctx val = ctx { _ctxExec = val }
 
-instance HasGetter (IOCtx chgAccum id value) (BaseMIOExec (DbAccess chgAccum id value) (IOCtx chgAccum id value)) where
+instance HasGetter
+           (IOCtx chgAccum id value)
+           (BaseMIOExec (DbAccess chgAccum id value) (IOCtx chgAccum id value)) where
     gett = _ctxExec
 
 instance HasLens (IOCtx chgAccum id value) (ChgAccumCtx (IOCtx chgAccum id value)) where
@@ -114,8 +121,8 @@ instance HasLens (IOCtx chgAccum id value) (ChgAccumCtx (IOCtx chgAccum id value
 instance HasGetter (IOCtx chgAccum id value) (ChgAccumCtx (IOCtx chgAccum id value)) where
     gett = _ctxChgAccum
 
-runERoCompIO ::
-       forall e id value chgAccum a ctx m.
+runERoCompIO
+    :: forall e id value chgAccum a ctx m.
        ( Show e
        , Typeable e
        , Default chgAccum
@@ -130,21 +137,21 @@ runERoCompIO ::
 runERoCompIO dba initAcc comp = do
     logger <- view (lensOf @Log.LoggingIO)
     liftIO $ Log.runRIO logger $ runBaseMIO comp $
-        IOCtx {
-            _ctxRestrict = def
+        IOCtx
+          { _ctxRestrict = def
           , _ctxChgAccum = maybe CANotInitialized CAInitialized initAcc
           , _ctxExec = exec
           , _ctxLogger = logger
           }
   where
     exec = BaseMIOExec $ \(getCAOrDefault . _ctxChgAccum -> chgAccum) dAccess ->
-      case dAccess of
-        DbQuery req cont                         -> cont <$> daaGetter dba chgAccum req
-        DbIterator prefix (FoldF (e, acc, cont)) -> cont <$> daaIter dba chgAccum prefix e acc
-        DbModifyAccum accum chgSet cont          -> cont <$> daaModifyAccum dba accum chgSet
+        case dAccess of
+            DbQuery req cont                         -> cont <$> daaGetter dba chgAccum req
+            DbIterator prefix (FoldF (e, acc, cont)) -> cont <$> daaIter dba chgAccum prefix e acc
+            DbModifyAccum accum chgSet cont          -> cont <$> daaModifyAccum dba accum chgSet
 
-runERwCompIO ::
-       ( Show e
+runERwCompIO
+    :: ( Show e
        , Typeable e
        , Default chgAccum
        , HasException e StatePException
@@ -159,15 +166,15 @@ runERwCompIO ::
 runERwCompIO dba initS comp = do
     logger <- view (lensOf @Log.LoggingIO)
     liftIO $ Log.runRIO logger $ runBaseMIO (runERwComp comp initS) $
-        IOCtx {
-          _ctxRestrict = def
-        , _ctxChgAccum = CANotInitialized
-        , _ctxExec = exec
-        , _ctxLogger = logger
-        }
+        IOCtx
+          { _ctxRestrict = def
+          , _ctxChgAccum = CANotInitialized
+          , _ctxExec = exec
+          , _ctxLogger = logger
+          }
   where
     exec = BaseMIOExec $ \(getCAOrDefault . _ctxChgAccum -> chgAccum) dAccess ->
-      case dAccess of
-        DbQuery req cont                         -> cont <$> daaGetter dba chgAccum req
-        DbIterator prefix (FoldF (e, acc, cont)) -> cont <$> daaIter dba chgAccum prefix e acc
-        DbModifyAccum accum chgSet cont          -> cont <$> daaModifyAccum dba accum chgSet
+        case dAccess of
+            DbQuery req cont                         -> cont <$> daaGetter dba chgAccum req
+            DbIterator prefix (FoldF (e, acc, cont)) -> cont <$> daaIter dba chgAccum prefix e acc
+            DbModifyAccum accum chgSet cont          -> cont <$> daaModifyAccum dba accum chgSet

--- a/snowdrop-execution/src/Snowdrop/Execution/Mempool/Logic.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/Mempool/Logic.hs
@@ -27,7 +27,9 @@ import           Snowdrop.Util
 -- Logic
 ---------------------------
 
-evictMempool :: Default (ChgAccum ctx) => RwActionWithMempool e id value rawtx ctx [(rawtx, Undo id value)]
+evictMempool
+    :: Default (ChgAccum ctx)
+    => RwActionWithMempool e id value rawtx ctx [(rawtx, Undo id value)]
 evictMempool = gets msTxs <* put def
 
 processTxAndInsertToMempool
@@ -42,7 +44,7 @@ processTxAndInsertToMempool MempoolConfig{..} rawtx = do
     undo <- mcProcessTx tx
     msTxsL %= (++ [(rawtx, undo)])
 
-newtype Rejected rawtx = Rejected {getRejected :: [rawtx]}
+newtype Rejected rawtx = Rejected { getRejected :: [rawtx] }
 
 normalizeMempool
     :: ( HasException e StatePException, Show e, Typeable e

--- a/snowdrop-execution/src/Snowdrop/Execution/Restrict.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/Restrict.hs
@@ -40,8 +40,8 @@ instance Default RestrictCtx where
 
 restrictDbAccess
     :: forall e id value ctx a .
-       ( HasLens ctx RestrictCtx
-       )
+    ( HasLens ctx RestrictCtx
+    )
     => Set Prefix
     -> ERoComp e id value ctx a
     -> ERoComp e id value ctx a
@@ -52,10 +52,10 @@ restrictDbAccess ps = local (lensFor @ctx @RestrictCtx %~ modCtx)
 
 restrictCS
     :: forall e id value m .
-       ( MonadError e m
-       , HasException e RestrictionInOutException
-       , IdSumPrefixed id
-       )
+    ( MonadError e m
+    , HasException e RestrictionInOutException
+    , IdSumPrefixed id
+    )
     => Set Prefix
     -> ChangeSet id value
     -> m ()
@@ -63,10 +63,10 @@ restrictCS out cs = throwResInpOutEx OutRestrictionException out (M.keysSet $ ch
 
 throwResInpOutEx
     :: forall e id m .
-       ( MonadError e m
-       , HasException e RestrictionInOutException
-       , IdSumPrefixed id
-       )
+    ( MonadError e m
+    , HasException e RestrictionInOutException
+    , IdSumPrefixed id
+    )
     => (Set Prefix -> RestrictionInOutException)
     -> Set Prefix
     -> Set id

--- a/snowdrop-execution/src/Snowdrop/Execution/Restrict.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/Restrict.hs
@@ -40,8 +40,8 @@ instance Default RestrictCtx where
 
 restrictDbAccess
     :: forall e id value ctx a .
-    ( HasLens ctx RestrictCtx
-    )
+       ( HasLens ctx RestrictCtx
+       )
     => Set Prefix
     -> ERoComp e id value ctx a
     -> ERoComp e id value ctx a
@@ -52,10 +52,10 @@ restrictDbAccess ps = local (lensFor @ctx @RestrictCtx %~ modCtx)
 
 restrictCS
     :: forall e id value m .
-    ( MonadError e m
-    , HasException e RestrictionInOutException
-    , IdSumPrefixed id
-    )
+       ( MonadError e m
+       , HasException e RestrictionInOutException
+       , IdSumPrefixed id
+       )
     => Set Prefix
     -> ChangeSet id value
     -> m ()
@@ -63,7 +63,10 @@ restrictCS out cs = throwResInpOutEx OutRestrictionException out (M.keysSet $ ch
 
 throwResInpOutEx
     :: forall e id m .
-    ( MonadError e m, HasException e RestrictionInOutException, IdSumPrefixed id)
+       ( MonadError e m
+       , HasException e RestrictionInOutException
+       , IdSumPrefixed id
+       )
     => (Set Prefix -> RestrictionInOutException)
     -> Set Prefix
     -> Set id
@@ -71,5 +74,6 @@ throwResInpOutEx
 throwResInpOutEx ex restSet sids = do
     let prefixes = S.fromList $ map idSumPrefix $ S.toList sids
     let diff = prefixes `S.difference` restSet
-    if S.null diff then pure ()
+    if S.null diff
+    then pure ()
     else throwLocalError $ ex diff

--- a/snowdrop-util/src/Snowdrop/Util/Containers.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Containers.hs
@@ -1,14 +1,14 @@
 module Snowdrop.Util.Containers
-    (
-      OldestFirst (..)
-    , NewestFirst (..)
-    , oldestFirstFContainer
-    , newestFirstFContainer
-    , toDummyMap
-    , toOldestFirst
-    , mapSet
-    , mapKeys
-    ) where
+       (
+         OldestFirst (..)
+       , NewestFirst (..)
+       , oldestFirstFContainer
+       , newestFirstFContainer
+       , toDummyMap
+       , toOldestFirst
+       , mapSet
+       , mapKeys
+       ) where
 
 import           Universum hiding (head, init, last)
 

--- a/snowdrop-util/src/Snowdrop/Util/Helpers.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Helpers.hs
@@ -1,22 +1,24 @@
 module Snowdrop.Util.Helpers
-    (
-      VerRes (..)
-    , VerifySign (..)
-    , IdStorage
-    , getId
-    , eitherToVerRes
-    , verResToEither
-    , runExceptTV
-    , WithSignature (..)
-    , propagateSecondF
-    , PublicKey
-    , Signature
-    , Signed (..)
-    ) where
+       (
+         VerRes (..)
+       , VerifySign (..)
+       , IdStorage
+       , getId
+       , eitherToVerRes
+       , verResToEither
+       , runExceptTV
+       , WithSignature (..)
+       , propagateSecondF
+       , PublicKey
+       , Signature
+       , Signed (..)
+       ) where
 
 import           Universum hiding (head, init, last)
+
 import qualified Data.Text.Buildable
 import           Formatting (bprint, build, (%))
+
 import           Snowdrop.Util.Prism.Class
 
 data family PublicKey sigScheme :: *
@@ -31,14 +33,21 @@ data Signed sigScheme msg = Signed
     , signature :: Signature sigScheme msg
     } deriving (Generic)
 
-deriving instance (Show (PublicKey sigScheme), Show (Signature sigScheme msg), Show msg) => Show (Signed sigScheme msg)
-deriving instance (Eq (PublicKey sigScheme), Eq (Signature sigScheme msg), Eq msg) => Eq (Signed sigScheme msg)
-deriving instance (Ord (PublicKey sigScheme), Ord (Signature sigScheme msg), Ord msg) => Ord (Signed sigScheme msg)
+deriving instance (Show (PublicKey sigScheme),
+                   Show (Signature sigScheme msg),
+                   Show msg) => Show (Signed sigScheme msg)
+deriving instance (Eq (PublicKey sigScheme),
+                   Eq (Signature sigScheme msg),
+                   Eq msg) => Eq (Signed sigScheme msg)
+deriving instance (Ord (PublicKey sigScheme),
+                   Ord (Signature sigScheme msg),
+                   Ord msg) => Ord (Signed sigScheme msg)
 
 instance (Hashable (PublicKey sigScheme), Hashable (Signature sigScheme msg),
           Hashable msg) => Hashable (Signed sigScheme msg)
 
-instance (Buildable (PublicKey sigScheme), Buildable (Signature sigScheme msg)) => Buildable (Signed sigScheme msg) where
+instance (Buildable (PublicKey sigScheme),
+          Buildable (Signature sigScheme msg)) => Buildable (Signed sigScheme msg) where
     build (Signed _ pk sig) =
         -- We omit 'message' for purpose. Currently 'Signed' is used
         -- in witnesses, and witness is always coupled with related transaction.
@@ -48,7 +57,6 @@ class (HasPrism s a, Enum s) => IdStorage s a
 
 getId :: forall ids i . IdStorage ids i => Proxy ids -> i -> Int
 getId _ i = fromEnum (inj i :: ids)
-
 
 -- to avoid orphan instance for Either and change definition of Monoid for Either
 

--- a/snowdrop-util/src/Snowdrop/Util/Lens.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Lens.hs
@@ -1,8 +1,8 @@
 module Snowdrop.Util.Lens
-    (
-      HasGetter (..)
-    , HasLens (..)
-    ) where
+       (
+         HasGetter (..)
+       , HasLens (..)
+       ) where
 
 import           Universum hiding (head, init, last)
 

--- a/snowdrop-util/src/Snowdrop/Util/Logging.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Logging.hs
@@ -2,27 +2,27 @@
 {-# LANGUAGE RankNTypes          #-}
 
 module Snowdrop.Util.Logging
-    (
-      RIO (..)
-    , ExecM
-    , runRIO
+       (
+         RIO (..)
+       , ExecM
+       , runRIO
 
-    , LogEvent
-    , withLogger
-    , LoggingIO
-    , lensOf
-    , MonadLogging (..)
-    , ModifyLogName (..)
-    , NameSelector (..)
-    , CanLog
+       , LogEvent
+       , withLogger
+       , LoggingIO
+       , lensOf
+       , MonadLogging (..)
+       , ModifyLogName (..)
+       , NameSelector (..)
+       , CanLog
 
-    -- * Loggers
-    , logDebug
-    , logError
-    , logWarning
-    , logInfo
-    , modifyLogName
-    ) where
+       -- * Loggers
+       , logDebug
+       , logError
+       , logWarning
+       , logInfo
+       , modifyLogName
+       ) where
 
 import           Universum
 
@@ -65,13 +65,11 @@ deriving instance MonadBase IO (RIO ctx) => MonadBaseControl IO (RIO ctx)
 runRIO :: MonadIO m => ctx -> RIO ctx a -> m a
 runRIO ctx (RIO act) = liftIO $ runReaderT act ctx
 
-instance (HasLens LoggingIO ctx LoggingIO) =>
-         MonadLogging (RIO ctx) where
+instance (HasLens LoggingIO ctx LoggingIO) => MonadLogging (RIO ctx) where
     log = Rio.defaultLog
     logName = Rio.defaultLogName
 
-instance (HasLens LoggingIO ctx LoggingIO) =>
-         ModifyLogName (RIO ctx) where
+instance (HasLens LoggingIO ctx LoggingIO) => ModifyLogName (RIO ctx) where
     modifyLogNameSel = Rio.defaultModifyLogNameSel
 
 type ExecM = RIO LoggingIO
@@ -92,28 +90,29 @@ defaultLogCfg = LW.productionB & LW.lcTermSeverityOut .~ Just mempty
 
     mkTree :: FilePath -> LW.LoggerTree
     mkTree logPath =
-      mempty & LW.ltSeverity .~ Just LW.infoPlus
-             & LW.ltSubloggers .~ mempty
-             & LW.ltFiles .~ [LW.HandlerWrap logPath Nothing]
+        mempty & LW.ltSeverity .~ Just LW.infoPlus
+               & LW.ltSubloggers .~ mempty
+               & LW.ltFiles .~ [LW.HandlerWrap logPath Nothing]
 
     subloggersMap :: LW.LoggerMap
     subloggersMap = HM.fromList
-      [ (LW.LoggerName "Server", mkTree "Server.log")
-      , (LW.LoggerName "Client", mkTree "Client.log")
-      ]
+        [ (LW.LoggerName "Server", mkTree "Server.log")
+        , (LW.LoggerName "Client", mkTree "Client.log")
+        ]
 
 
 -- TODO: finalise config from `ConfigPart`s
 withLogger :: Maybe FilePath -> ExecM () -> IO ()
 withLogger mConfigPath action = do
     cfg <- case mConfigPath of
-        Nothing -> withColor Term.Yellow (putTextLn "Using the default logger configuration") >> return defaultLogCfg
-        Just path -> decodeFileEither path >>= \case
-          Right cfgFromYmal -> return cfgFromYmal
-          Left err -> do
-            withColor Term.Red (putTextLn "Error: ") >> print err
-            withColor Term.Red (putTextLn "Default log config will be used.")
+        Nothing -> withColor Term.Yellow (putTextLn "Using the default logger configuration") >>
             return defaultLogCfg
+        Just path -> decodeFileEither path >>= \case
+            Right cfgFromYmal -> return cfgFromYmal
+            Left err -> do
+                withColor Term.Red (putTextLn "Error: ") >> print err
+                withColor Term.Red (putTextLn "Default log config will be used.")
+                return defaultLogCfg
     bracket
       (prepareLogWarper cfg (GivenName $ fromString ""))
       (const removeAllHandlers)
@@ -124,6 +123,6 @@ withLogger mConfigPath action = do
   where
     withColor :: Term.Color -> IO () -> IO ()
     withColor col act = do
-      Term.setSGR [Term.SetColor Term.Foreground Term.Vivid col]
-      act
-      Term.setSGR [Term.Reset]
+        Term.setSGR [Term.SetColor Term.Foreground Term.Vivid col]
+        act
+        Term.setSGR [Term.Reset]

--- a/snowdrop-util/src/Snowdrop/Util/Prism/Class.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Prism/Class.hs
@@ -1,9 +1,9 @@
 module Snowdrop.Util.Prism.Class
-    (
-      HasReview (..)
-    , HasPrism (..)
-    , fPair
-    ) where
+       (
+         HasReview (..)
+       , HasPrism (..)
+       , fPair
+       ) where
 
 import           Universum hiding (head, init, last)
 
@@ -11,7 +11,8 @@ import           Control.Lens (Prism', Review, prism', re, unto)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 
--- TODO probably using lens package is overkill and we have to use manually defined Prism and Getter in future
+-- TODO probably using lens package is overkill and we have to use manually defined
+-- Prism and Getter in future
 
 class HasReview s a where
     {-# MINIMAL reviewOf | inj #-}
@@ -79,14 +80,17 @@ instance (Ord id, Ord id1, HasPrism id id1) => HasPrism (Set id) (Set id1) where
       where
         valsM = proj <$> S.toList vals
 
-instance (Ord id, HasReview id id1, HasReview value value1) => HasReview (M.Map id value) (M.Map id1 value1) where
+instance (Ord id, HasReview id id1, HasReview value value1)
+        => HasReview (M.Map id value) (M.Map id1 value1) where
     inj mid1 = M.fromList $ bimap inj inj <$> M.toList mid1
 
-instance (Ord id, Ord id1, HasPrism id id1, HasPrism value value1) => HasPrism (M.Map id value) (M.Map id1 value1) where
+instance (Ord id, Ord id1, HasPrism id id1, HasPrism value value1)
+        => HasPrism (M.Map id value) (M.Map id1 value1) where
     proj vals
         | isJust (find isNothing valsM)
             = Nothing -- TODO after we have more sensitive errors,
-                      -- have one error for "id returned unexpected value" and one for "unexpected id"
+                      -- have one error for "id returned unexpected value"
+                      -- and one for "unexpected id"
         | otherwise
             = Just $ M.fromList $ catMaybes valsM
       where

--- a/snowdrop-util/src/Snowdrop/Util/Prism/Exception.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Prism/Exception.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE DataKinds #-}
 
 module Snowdrop.Util.Prism.Exception
-    (
-      HasException
-    , HasExceptions
-    , HasReviews
-    , HasPrisms
+       (
+         HasException
+       , HasExceptions
+       , HasReviews
+       , HasPrisms
 
-    , eitherThrow
-    , maybeThrow
-    , maybeThrowLocal
-    , throwLocalError
-    ) where
+       , eitherThrow
+       , maybeThrow
+       , maybeThrowLocal
+       , throwLocalError
+       ) where
 
 import           Universum
 

--- a/snowdrop-util/src/Snowdrop/Util/Prism/TH.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Prism/TH.hs
@@ -1,10 +1,10 @@
 module Snowdrop.Util.Prism.TH
-    (
-      withInj
-    , withInjProj
-    , deriveView
-    , deriveIdView
-    ) where
+       (
+         withInj
+       , withInjProj
+       , deriveView
+       , deriveIdView
+       ) where
 
 import           Universum hiding (head, init, last)
 

--- a/snowdrop-util/src/Snowdrop/Util/Text.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Text.hs
@@ -3,30 +3,30 @@
 -- | Smart buildable stuff, text processing, e.t.c.
 
 module Snowdrop.Util.Text
-    (
-      Buildables
-    , maybeF
-    , listF
-    , bareListF
-    , pairF
-    , specifiedF
+       (
+         Buildables
+       , maybeF
+       , listF
+       , bareListF
+       , pairF
+       , specifiedF
 
-    , Doc
-    , DocParams
-    , DBuildable (..)
-    , DText
-    , DFormat
-    , docF
-    , dlater
-    , (%%)
-    , newline
-    , newlineF
-    , indented
-    , indentedLarge
-    , putDoc
-    , printDoc
-    , logDoc
-    ) where
+       , Doc
+       , DocParams
+       , DBuildable (..)
+       , DText
+       , DFormat
+       , docF
+       , dlater
+       , (%%)
+       , newline
+       , newlineF
+       , indented
+       , indentedLarge
+       , putDoc
+       , printDoc
+       , logDoc
+       ) where
 
 import           Universum hiding (head, init, last)
 
@@ -66,10 +66,10 @@ listF
     => Builder -> Format Builder (Exts.Item l -> Builder) -> Format r (l -> r)
 listF delim buildElem =
     later $ \(Exts.toList -> values) ->
-    if null values
-    then "[]"
-    else mconcat $
-         one "[" <> (intersperse delim $ bprint buildElem <$> values) <> one "]"
+        if null values
+        then "[]"
+        else mconcat $
+             one "[" <> (intersperse delim $ bprint buildElem <$> values) <> one "]"
 
 -- | Formatter for pair. Use with care.
 pairF
@@ -81,9 +81,10 @@ pairF buildA delim buildB =
     later $ \(a, b) -> bprint (buildA % now delim % buildB) a b
 
 -- | Print entires of pair separated with colon.
-specifiedF :: Format (b -> Builder) (a -> b -> Builder)
-           -> Format Builder (b -> Builder)
-           -> Format r ((a, b) -> r)
+specifiedF
+    :: Format (b -> Builder) (a -> b -> Builder)
+    -> Format Builder (b -> Builder)
+    -> Format r ((a, b) -> r)
 specifiedF buildA buildB = pairF buildA ": " buildB
 
 ------------------------------------------------------


### PR DESCRIPTION
- [ ] Document Snowdrop.Core.ChangeSet.Type
- [ ] Document Snowdrop.Core.ChangeSet.ValueOp
- [ ] Document Snowdrop.Core.ERoComp.Helpers
- [ ] Document Snowdrop.Core.ERwComp
- [ ] Note about `Expander` in Snowdrop.Core.Expander
- [ ] Comment `SValue`, `mkPartialStateTx` and `selectKeyValueCS` in Snowdrop.Core.Transaction
- [ ] Document Snowdrop.Core.Validator.Basic
- [ ] Document Snowdrop.Core.Validator.Types
- [ ] Document Snowdrop.Util.Helpers
- [ ] Document Snowdrop.Util.Logging
- [ ] Move comments from Snowdrop.Block.Application to docs (?)
- [ ] Add comments in Snowdrop.Block.Fork, uncomment `findLCA` function
- [ ] Document Snowdrop.Block.Types
- [ ] Comment `expandUnionRawTxs` in Snowdrop.Execution.Expand, probably move `expandRawTxs` comments to docs
- [ ] Document Snowdrop.Execution.IOExecutor
- [ ] Document Snowdrop.Execution.Restrict
- [ ] Add comments to Snowdrop.Execution.DbActions.AVLp
- [ ] Document Snowdrop.Execution.DbActions.Composite
- [ ] Document Snowdrop.Execution.DbActions.Simple
- [ ] Document Snowdrop.Execution.Mempool.Core
- [ ] Document Snowdrop.Execution.Mempool.Logic