### PR TITLE
[SD-142] Document code in snowdrop-{core,util,block}

### DIFF
--- a/snowdrop-block/src/Snowdrop/Block/Fork.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Fork.hs
@@ -35,7 +35,7 @@ data ForkVerResult blkType
       -- ^ Blocks to rollback.
       , fvrLCA        :: Maybe (BlockRef blkType)
       -- ^ Last block to be remained after rollback and predecessor of first block to apply.
-      -- $Nothing in case of whole blockchain is rolled back.
+      -- Value @Nothing@ is returned in case of whole blockchain is rolled back.
       }
     -- ^ Fork verification decision is to apply given fork.
     | RejectFork

--- a/snowdrop-block/src/Snowdrop/Block/Fork.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Fork.hs
@@ -29,7 +29,6 @@ import           Snowdrop.Util
 -- | Result of fork verification.
 data ForkVerResult blkType
     = ApplyFork
-    -- ^ Fork verification decision is to apply given fork.
       { fvrToApply    :: OldestFirst NonEmpty (BlockHeader blkType)
       -- ^ Headers of blocks to apply.
       , fvrToRollback :: NewestFirst [] (RawBlund blkType)
@@ -38,6 +37,7 @@ data ForkVerResult blkType
       -- ^ Last block to be remained after rollback and predecessor of first block to apply.
       -- $Nothing in case of whole blockchain is rolled back.
       }
+    -- ^ Fork verification decision is to apply given fork.
     | RejectFork
     -- ^ Fork verification decision is to reject given fork.
 

--- a/snowdrop-block/src/Snowdrop/Block/Fork.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Fork.hs
@@ -22,28 +22,40 @@ import           Formatting (bprint)
 
 import           Snowdrop.Block.Configuration (BlkConfiguration (..))
 import           Snowdrop.Block.StateConfiguration (BlkStateConfiguration (..))
-import           Snowdrop.Block.Types (Block (..), BlockRef, Blund (..),
-                                       CurrentBlockRef (..), BlockHeader,
-                                       RawBlund, OSParams, PrevBlockRef (..))
+import           Snowdrop.Block.Types (Block (..), BlockHeader, BlockRef, Blund (..),
+                                       CurrentBlockRef (..), OSParams, PrevBlockRef (..), RawBlund)
 import           Snowdrop.Util
 
+-- | Result of fork verification.
 data ForkVerResult blkType
-  = ApplyFork
+    = ApplyFork
+    -- ^ Fork verification decision is to apply given fork.
       { fvrToApply    :: OldestFirst NonEmpty (BlockHeader blkType)
+      -- ^ Headers of blocks to apply.
       , fvrToRollback :: NewestFirst [] (RawBlund blkType)
+      -- ^ Blocks to rollback.
       , fvrLCA        :: Maybe (BlockRef blkType)
+      -- ^ Last block to be remained after rollback and predecessor of first block to apply.
+      -- $Nothing in case of whole blockchain is rolled back.
       }
     | RejectFork
+    -- ^ Fork verification decision is to reject given fork.
 
+-- | Exception type for $verifyFork.
 data ForkVerificationException blkType
     = BlocksNotConsistent
-    -- | Exception will be thrown when parent of alt chain doesn't belong to our chain
+    -- ^ Chain of blocks is not self-consistent: either integrity berification of one of blocks failed
+    -- or one of blocks in the list is not a predcessor of following one.
     | UnkownForkOrigin
-    -- | Exception will be thrown when the first block of alt chain belongs to our chain
+    -- ^ Parent of alt chain doesn't belong to our chain.
     | InvalidForkOrigin
+    -- ^ First block of alt chain belongs to our chain.
     | TooDeepFork
+    -- ^ Given fork is too deep.
     | OriginOfBlockchainReached
+    -- ^ Origin of blockchain reached before an LCA is found.
     | BlockDoesntExistInChain blkType
+    -- ^ Wrong block reference occurred during chain traversal (of block that is not present in storage).
     deriving Show
 
 instance Buildable (ForkVerificationException blockRef) where
@@ -109,12 +121,13 @@ verifyFork BlkStateConfiguration{..} osParams fork@(OldestFirst altHeaders) = do
             Nothing -> throwLocalError $ BlockDoesntExistInChain from
         | otherwise = throwLocalError @(ForkVerificationException (BlockRef blkType)) OriginOfBlockchainReached
 
+-- | Load up to @maxDepth@ blocks from the currently adopted block sequence.
 iterateChain
     :: forall blkType m .
     ( Monad m
     )
     => BlkStateConfiguration blkType m
-    -> Int
+    -> Int -- ^ Max depth of block sequence to load.
     -> m (NewestFirst [] (RawBlund blkType))
 iterateChain BlkStateConfiguration{..} maxDepth = bscGetTip >>= loadBlock maxDepth
   where
@@ -130,35 +143,3 @@ iterateChain BlkStateConfiguration{..} maxDepth = bscGetTip >>= loadBlock maxDep
                 loadBlock
                   (depth - 1)
                   (unPrevBlockRef . (bcPrevBlockRef bscConfig) . blkHeader . buBlock $ b)
-
--- TODO this function may be needed in future
-
--- | Finds LCA of two containers `cont1`, `cont2`
---   Returns `(lca, cont1', cont2')` such that:
---    * `blkOrigin cont1' == blkOrigin cont2' == lca`
---    * `cont1'` and `cont2'` are heads of `cont1`, `cont2` respectively.
--- findLCA
---     :: (HasBlock blockRef payload bdata1, HasBlock blockRef payload bdata2, Ord blockRef)
---     => Int
---     -> BlockContainerD blockRef bdata1 payload
---     -> BlockContainerD blockRef bdata2 payload
---     -> Maybe (blockRef,
---               BlockContainerM blockRef bdata1 payload,
---               BlockContainerM blockRef bdata2 payload)
--- findLCA maxDepth cont1 cont2 = do
---     (lca, dropTail lca -> cont2) <- lcaM
---     (_, dropTail lca -> cont1) <- find ((==) lca . fst) refs1
---     assertOrigin lca cont1 $
---       assertOrigin lca cont2 $
---       return (lca, cont1, cont2)
---   where
---     assertOrigin origin = assert . maybe True ((== Just origin) . blkOrigin)
-
---     dropTail tailKey (m, tip)
---         | tip == tailKey = Nothing
---         | otherwise = Just (M.delete tailKey m, tip)
-
---     lcaM = find (flip S.member refs1Set . fst) refs2
---     NewestFirst (take maxDepth -> refs1) = blkHeads (Just cont1)
---     refs1Set = S.fromList (fst <$> refs1)
---     NewestFirst (take maxDepth -> refs2) = blkHeads (Just cont2)

--- a/snowdrop-block/src/Snowdrop/Block/State.hs
+++ b/snowdrop-block/src/Snowdrop/Block/State.hs
@@ -22,10 +22,9 @@ import           Snowdrop.Block.Types (Block (..), BlockHeader, BlockRef, BlockU
                                        CurrentBlockRef (..), Payload, RawBlk, RawPayload)
 import           Snowdrop.Core (CSMappendException (..), ChangeSet (..), ChgAccum, ChgAccumCtx,
                                 ChgAccumModifier (..), ERwComp, HasKeyValue, IdSumPrefixed (..),
-                                SomeTx, StateModificationException, StatePException (..),
-                                StateTx (..), Undo (..), Validator, ValueOp (..), applySomeTx,
-                                liftERoComp, mappendChangeSet, modifyRwCompChgAccum, queryOne,
-                                queryOneExists, runValidator)
+                                SomeTx, StatePException (..), StateTx (..), Undo (..), Validator,
+                                ValueOp (..), applySomeTx, liftERoComp, mappendChangeSet,
+                                modifyRwCompChgAccum, queryOne, queryOneExists, runValidator)
 import           Snowdrop.Execution (ProofNExp (..), RestrictCtx, RestrictionInOutException,
                                      expandUnionRawTxs)
 import           Snowdrop.Util
@@ -61,7 +60,6 @@ inmemoryBlkStateConfiguration
     , HasExceptions e
         [ StatePException
         , BlockStateException id
-        , StateModificationException id
         , CSMappendException id
         , RestrictionInOutException
         ]

--- a/snowdrop-block/src/Snowdrop/Block/Types.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Types.hs
@@ -14,59 +14,71 @@ module Snowdrop.Block.Types
        , RawBlund
        , RawPayload
        , OSParams
-       , Time
        ) where
 
 import           Universum
-
-import           Data.Time.Clock (UTCTime)
-
-type Time = UTCTime
 
 -------------------------------
 -- Block storage
 -------------------------------
 
-type family BlockRef a :: *
+-- | Block reference type, parametrized by unified parameter of block configuration @blkType@
+type family BlockRef blkType :: *
 
-type family Payload a :: *
+-- | Block payload type, parametrized by unified parameter of block configuration @blkType@
+type family Payload blkType :: *
 
-type family BlockHeader a :: *
+-- | Block header type, parametrized by unified parameter of block configuration @blkType@
+type family BlockHeader blkType :: *
 
-type family BlockUndo a :: *
+-- | Block undo type, parametrized by unified parameter of block configuration @blkType@
+type family BlockUndo blkType :: *
 
-type family OSParams a :: *
+-- | OS params type, parametrized by unified parameter of block configuration @blkType@
+type family OSParams blkType :: *
 
-type family RawBlk a :: *
+-- | Raw block type, parametrized by unified parameter of block configuration @blkType@
+type family RawBlk blkType :: *
 
-type family RawPayload a :: *
+-- | Raw block's payload type, parametrized by unified parameter of block configuration @blkType@
+type family RawPayload blkType :: *
 
+-- | Type, representing a block.
+-- Isomorphic to a pair @(header, payload)@.
 data Block header payload = Block
     { blkHeader  :: header
     , blkPayload :: payload
     } deriving (Show, Eq, Ord, Generic)
 
+-- TODO consider removing HasBlock type class and using $HasGetter in its stead
+
+-- | Getter type class for a block
 class HasBlock header payload b where
     getBlock :: b -> Block header payload
 
 instance HasBlock header payload (Block header payload) where
     getBlock = identity
 
+-- | Type for a block with respective undo object.
+-- Isomorphic to a tuple @(header, payload, undo)@.
 data Blund header payload undo = Blund
     { buBlock :: Block header payload
     , buUndo  :: undo
     } deriving (Eq, Ord, Show, Generic)
 
+-- | $Blund type, parametrized with raw payload.
 type RawBlund blkType =
     (Blund (BlockHeader blkType) (RawPayload blkType) (BlockUndo blkType))
 
 instance HasBlock header payload (Blund header payload undo) where
     getBlock = getBlock . buBlock
 
+-- | Wrapper type for reference of itself for some block.
 newtype CurrentBlockRef blkType = CurrentBlockRef
     { unCurrentBlockRef :: BlockRef blkType
     }
 
+-- | Wrapper type for reference of previous block for some block.
 newtype PrevBlockRef blkType = PrevBlockRef
     { unPrevBlockRef :: (Maybe (BlockRef blkType))
     }

--- a/snowdrop-core/src/Snowdrop/Core/ChangeSet/Type.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ChangeSet/Type.hs
@@ -34,6 +34,7 @@ import           Snowdrop.Util
 -- | ChangeSet is a basic datatype. It reflects changes over a key-value storage.
 -- ChangeSet holds Map from a key in database to an operation
 -- which should be performed over the state by this key.
+-- For more information see Snowdrop.Core.ChangeSet.ValueOp.
 newtype ChangeSet id v = ChangeSet {changeSet :: M.Map id (ValueOp v)}
     deriving (Functor, Eq, Ord, Show)
 

--- a/snowdrop-core/src/Snowdrop/Core/ChangeSet/Type.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ChangeSet/Type.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveFunctor #-}
 
+-- | Description of ChangeSet and basic functions to work with it.
+
 module Snowdrop.Core.ChangeSet.Type
        ( ChangeSet (..)
        , Undo (..)
@@ -11,11 +13,9 @@ module Snowdrop.Core.ChangeSet.Type
        , CSMappendException (..)
        , mappendChangeSet
        , mconcatChangeSets
-       , splitByPrefix
        , filterByPrefix
        , filterByPrefixPred
        , filterSetByPrefixPred
-       , mapKeysMonotonicCS
        ) where
 
 import           Universum hiding (head, init, last)
@@ -31,8 +31,14 @@ import           Snowdrop.Core.ChangeSet.ValueOp (ValueOp (..), ValueOpEx (..))
 import           Snowdrop.Core.Prefix (IdSumPrefixed (..), Prefix (..))
 import           Snowdrop.Util
 
+-- | ChangeSet is a basic datatype. It reflects changes over a key-value storage.
+-- ChangeSet holds Map from a key in database to an operation
+-- which should be performed over the state by this key.
 newtype ChangeSet id v = ChangeSet {changeSet :: M.Map id (ValueOp v)}
     deriving (Functor, Eq, Ord, Show)
+
+instance Default (ChangeSet id v) where
+    def = ChangeSet def
 
 instance (Ord id, HasReview id id1, HasReview value value1)
       => HasReview (ChangeSet id value) (ChangeSet id1 value1) where
@@ -42,29 +48,38 @@ instance (Ord id, Ord id1, HasPrism id id1, HasPrism value value1)
       => HasPrism (ChangeSet id value) (ChangeSet id1 value1) where
     proj (ChangeSet mp) = ChangeSet <$> proj mp
 
+-- | Undo holds changes which must be applied to state to get a previous state.
 data Undo id value = Undo
     { undoChangeSet :: ChangeSet id value
     , undoSnapshot  :: ByteString
+    -- ^ Version of AVL tree to rollback. To be removed and abstracted.
     } deriving (Show, Eq, Generic)
 
+-- | Returns a set of keys which Rem operation should be applied to.
 csRemove :: ChangeSet id v -> Set id
 csRemove = M.keysSet . M.filter isRem . changeSet
   where
     isRem Rem = True
     isRem _   = False
 
+-- | Returns a map containg keys which New operation should be applied to
+-- and corresponding new values according to ChangeSet.
 csNew :: ChangeSet id v -> Map id v
 csNew = M.mapMaybe isNew . changeSet
   where
     isNew (New x) = Just x
     isNew _       = Nothing
 
+-- | Returns a map containg keys which Upd operation should be applied to
+-- and corresponding new values according to ChangeSet.
 csUpdate :: ChangeSet id v -> Map id v
 csUpdate = M.mapMaybe isUpd . changeSet
   where
     isUpd (Upd x) = Just x
     isUpd _       = Nothing
 
+-- | Returns map consisted of keys corresponding to New and Upd operations and
+-- values from operations themselves.
 changeSetToMap :: ChangeSet id v -> Map id v
 changeSetToMap = M.mapMaybe toJust . changeSet
   where
@@ -73,12 +88,11 @@ changeSetToMap = M.mapMaybe toJust . changeSet
     toJust (Upd x)    = Just x
     toJust (New x)    = Just x
 
+-- | Like @changeSetToMap@ but returns a list.
 changeSetToList :: ChangeSet id v -> [(id, ValueOp v)]
 changeSetToList (ChangeSet mp) = M.toList mp
 
-instance Default (ChangeSet id v) where
-    def = ChangeSet def
-
+-- | Exception throwing from @mappendChangeSet@.
 newtype CSMappendException id = CSMappendException id
     deriving (Show, Eq)
 
@@ -88,7 +102,12 @@ instance Buildable id => Buildable (CSMappendException id) where
     build (CSMappendException i) =
         bprint ("Failed to mappend ChangeSets due to conflict for key "%build) i
 
--- This tricky implementation works for O(min(N, M) * log(max(N, M)))
+-- | Combine @ValueOp@s corresponding the same keys.
+-- @CSMappendException@ will be returned if after an aplication of
+-- the first ChangeSet to a state it won't be possible to apply the second ChangeSet
+-- without violation ValueOp's invariant.
+-- Don't apply any changes to state itself.
+-- This implementation works for O(min(N, M) * log(max(N, M)))
 mappendChangeSet
     :: Ord id
     => ChangeSet id v
@@ -111,29 +130,19 @@ mappendChangeSet (ChangeSet m1) (ChangeSet m2) = if leftAppRight
                 Err   -> Left $ CSMappendException i
                 Op ro -> Right $ M.insert i ro m
 
+-- | Like @mconcatChangeSet@ but for list of ChangeSet.
 mconcatChangeSets :: Ord id => [ChangeSet id v] -> Either (CSMappendException id) (ChangeSet id v)
 mconcatChangeSets = foldM mappendChangeSet def
 
-splitByPrefix
-    :: forall id v . (IdSumPrefixed id, Ord id)
-    => ChangeSet id v
-    -> M.Map Prefix (ChangeSet id v)
-splitByPrefix (ChangeSet c) = M.foldrWithKey f mempty c
-  where
-    f i v = M.alter (alterF i v) (idSumPrefix i)
-
-    alterF i csVal Nothing   = Just $ ChangeSet $ M.singleton i csVal
-    alterF i csVal (Just cs) = Just $ ChangeSet $ M.insert i csVal $ changeSet cs
-
-filterByPrefix :: IdSumPrefixed id => Prefix -> ChangeSet id v -> ChangeSet id v
-filterByPrefix p = filterByPrefixPred (== p)
-
+-- | Returns only those entries where key's prefix satisfies the predicate.
 filterByPrefixPred :: IdSumPrefixed id => (Prefix -> Bool) -> ChangeSet id v -> ChangeSet id v
 filterByPrefixPred predicate
     = ChangeSet . M.filterWithKey (curry (predicate . idSumPrefix . fst)) . changeSet
 
+-- | Returns only those entries where key's prefix equals to the passed prefix.
+filterByPrefix :: IdSumPrefixed id => Prefix -> ChangeSet id v -> ChangeSet id v
+filterByPrefix p = filterByPrefixPred (== p)
+
+-- | Returns only those elements where key's prefix satisfies the predicate.
 filterSetByPrefixPred :: IdSumPrefixed id => (Prefix -> Bool) -> Set id -> Set id
 filterSetByPrefixPred predicate mp = S.filter (predicate . idSumPrefix) mp
-
-mapKeysMonotonicCS :: Ord id1 => (id -> id1) -> ChangeSet id val -> ChangeSet id1 val
-mapKeysMonotonicCS f = ChangeSet . M.mapKeysMonotonic f . changeSet

--- a/snowdrop-core/src/Snowdrop/Core/ChangeSet/ValueOp.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ChangeSet/ValueOp.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE DeriveTraversable #-}
 
+-- | ValueOp primitive.
+
 module Snowdrop.Core.ChangeSet.ValueOp
        (
          ValueOp (..)
@@ -12,11 +14,30 @@ import           Universum hiding (head, init, last)
 
 import           Snowdrop.Util
 
+-- | ValueOp datatype is an action which should be performed over an entry
+-- stored in a key-value storage. Intended to be used in @ChangeSet@,
+-- in Map Id (ValueOp Value).
 data ValueOp v
     = New v
+    -- ^ @New@ operation requires the following invariants (both of them):
+    --   1. key which holds this ValueOp doesn't exist in a state,
+    --   2. after aplication of entry (key, New v) to the state a value stored
+    --      by @key@ is @v@.
     | Upd v
+    -- ^ @Upd@ operation requires the following invariants (both of them):
+    --   1. key which holds this ValueOp exists in a state,
+    --   2. after aplication of entry (key, Upd v) to the state a value stored
+    --      by @key@ is @v@.
     | Rem
+    -- ^ @Rem@ operation requires the following invariants (both of them):
+    --   1. key which holds this ValueOp exists in a state,
+    --   2. after aplication of entry (key, Rem) to the state the @key@ doesn't
+    -- exist in the state anymore.
     | NotExisted
+    -- ^ @NotExisted@ operation requires the following invariant:
+    -- key which holds this ValueOp doesn't exist in a state.
+    -- This operation has no side effects with respect to the state.
+    -- However, if invariant isn't hold an exception will be caused.
     deriving (Functor, Foldable, Traversable, Show, Eq, Ord, Generic)
 
 instance HasReview v v1 => HasReview (ValueOp v) (ValueOp v1) where
@@ -28,6 +49,9 @@ instance HasPrism v v1 => HasPrism (ValueOp v) (ValueOp v1) where
     proj (New v)    = New <$> proj v
     proj (Upd v)    = Upd <$> proj v
 
+-- | Auxiliary datatype to provide Semigroup instance for ValueOp.
+-- ValueOp doesn't hold Semigroup laws, but it holds if there is
+-- an additional constructor corresponding error during mappend.
 data ValueOpEx v
     = Op (ValueOp v)
     | Err

--- a/snowdrop-core/src/Snowdrop/Core/ERoComp/Types.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERoComp/Types.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE DeriveFunctor #-}
 
+-- | Basic types for Exceptionable Read-Only Computation.
+
 module Snowdrop.Core.ERoComp.Types
-       (
-         Prefix (..)
+       ( Prefix (..)
        , IdSumPrefixed (..)
        , StateR
        , StateP
@@ -23,14 +24,54 @@ import           Snowdrop.Core.BaseM (BaseM)
 import           Snowdrop.Core.ChangeSet (CSMappendException (..), ChangeSet (..), Undo)
 import           Snowdrop.Core.Prefix (IdSumPrefixed (..), Prefix (..))
 
-type StateR id = Set id             -- ^Request of state
-type StateP id value = Map id value -- ^Portion of state
+-- | Set of requested keys from a key-value storage.
+type StateR id = Set id
 
+-- | Result of request.
+type StateP id value = Map id value
+
+-- | Datatype describing read only interface for access to a state.
+-- By "access" it's meant any interation with any kind of external state,
+-- including: in-memory, persistent etc.
+-- @id@, @values@ describes types of key and value of key-value storage.
+-- @chgAccum@ is in-memory state of snowdrop.
+data DbAccess chgAccum id value res
+    = DbQuery (StateR id) (StateP id value -> res)
+    -- ^ Request to state.
+    -- The first field is request set of keys which are requested from state.
+    -- The second one is a callback which accepts result of request: Map key value
+    -- and returns a continuation (a next request to state).
+    | DbIterator Prefix (FoldF (id, value) res)
+    -- ^ Iteration over state.
+    -- The first field is prefix for iteration over keys with this prefix.
+    -- The second one is used to accumulate entries during iteration.
+    | DbModifyAccum
+        chgAccum
+        (ChgAccumModifier id value)
+        (Either (CSMappendException id) (chgAccum, Undo id value) -> res)
+    -- ^ Operation to modify Change Accumulator.
+    -- This action doesn't imply an explicit access to state,
+    -- but AVL tree requires this access. This operation is read only,
+    -- so it doesn't affect passed @chgAccum@ and doesn't produce any changes id db.
+    deriving (Functor)
+
+-- | Change accum modifier object.
+-- Holds either change set or undo object which is to be applied to change accumulator.
+data ChgAccumModifier id value
+    = CAMChange { camChg  :: ChangeSet id value }
+    | CAMRevert { camUndo :: Undo id value }
+
+-- | FoldF holds functions which are intended to accumulate result of iteratio
+-- over entries.
+-- The first field is an initial value.
+-- The second one is an accumulator.
+-- The third one is convertor result of iteration to continuation (a next request to state).
 data FoldF a res = forall b. FoldF (b, a -> b -> b, b -> res)
 
 instance Functor (FoldF a) where
     fmap f (FoldF (e, foldf, applier)) = FoldF (e, foldf, f . applier)
 
+-- | Mappend operation for two @FoldF@s.
 foldFMappend :: (res -> res -> res) -> FoldF a res -> FoldF a res -> FoldF a res
 foldFMappend resMappend (FoldF (e1, f1, applier1)) (FoldF (e2, f2, applier2))
     = FoldF (e, f, applier)
@@ -39,42 +80,20 @@ foldFMappend resMappend (FoldF (e1, f1, applier1)) (FoldF (e2, f2, applier2))
     f a (b1, b2) = (f1 a b1, f2 a b2)
     applier (b1, b2) = applier1 b1 `resMappend` applier2 b2
 
--- We can't define Monoid for FoldF a res because we can't define mempty (without undefined)
+-- It can't be defined Monoid instance for @FoldF@ because @mempty@ can't be defined.
 instance Semigroup res => Semigroup (FoldF a res) where
     f1 <> f2 = foldFMappend (<>) f1 f2
 
--- | Change accum modifier object.
--- Holds either change set or undo object which is to be applied to change accumulator.
-data ChgAccumModifier id value
-    = CAMChange { camChg  :: ChangeSet id value }
-    | CAMRevert { camUndo :: Undo id value }
-
--- Datatype for access to database.
---
---     * mappend of two DbQuery executes as one DBQuery (as one Free iteration)
---     * mappend of DBIterator and x makes DBIterator execute one iteration of Free
---     and require one more for x
---
--- It's essential to understand that unlike DBQuery,
--- iterator always requires additional Free iteration.
--- Given iterators are to be used rarely, this shall be ok.
-data DbAccess chgAccum id value res
-    = DbQuery (StateR id) (StateP id value -> res)
-    | DbIterator Prefix (FoldF (id, value) res)
-    | DbModifyAccum
-        chgAccum
-        (ChgAccumModifier id value)
-        (Either (CSMappendException id) (chgAccum, Undo id value) -> res)
-    deriving (Functor)
+-- | Change Accumulator is in-memory state of snowdrop's functions.
+-- Most likely it should be consisnted with persistent state because it's just
+-- one more layer of state which must be considered during access to state.
+-- Also it has to be possible to apply ChangeSet to this Change Accumulator.
+type family ChgAccum ctx :: *
 
 -- | Reader computation which allows you to query for part of bigger state
 -- and build computation considering returned result.
---
--- Note, response might contain more records than were requested in `req`
--- (because of monoidal gluing of many computations)
-
-type family ChgAccum ctx :: *
-
+-- DbAccess is used as an effect of BaseM.
 type ERoComp e id value ctx = BaseM e (DbAccess (ChgAccum ctx) id value) ctx
 
+-- | Auxiliary datatype for context-dependant computations.
 data ChgAccumCtx ctx = CANotInitialized | CAInitialized (ChgAccum ctx)

--- a/snowdrop-core/src/Snowdrop/Core/Expander.hs
+++ b/snowdrop-core/src/Snowdrop/Core/Expander.hs
@@ -21,14 +21,14 @@ import           Snowdrop.Core.ChangeSet (ChangeSet (..), ValueOp (..))
 import           Snowdrop.Core.ERoComp (ERoComp)
 import           Snowdrop.Core.Prefix (Prefix)
 
--- type Expander e id value ctx rawTx (txtypes :: [*]) = Rec (PreExpanderSeq e id value ctx rawTx) txtypes
-
+-- | Sequence of expand stages to be consequently executed upon a given transaction.
 newtype SeqExpander e id value ctx rawTx
   = SeqExpander { getSeqExpanders :: SeqExpander' e id value ctx rawTx }
 
 instance Contravariant (SeqExpander e id value ctx) where
     contramap g = SeqExpander . NE.map (contramap g) . getSeqExpanders
 
+-- | Sequence of expand stages to be consequently executed upon a given transaction (unwrapped).
 type SeqExpander' e id value ctx rawTx = NonEmpty (PreExpander e id value ctx rawTx)
 
 -- | PreExpander allows you to convert one raw tx to StateTx.
@@ -46,8 +46,9 @@ data PreExpander e id value ctx rawTx = PreExpander
 instance Contravariant (PreExpander e id value ctx) where
     contramap g (PreExpander s1 s2 f) = PreExpander s1 s2 (f . g)
 
--- | DiffChangeSet holds changes which one expander returns
+-- | DiffChangeSet holds changes which one $PreExpander returns
 newtype DiffChangeSet id value = DiffChangeSet {unDiffCS :: ChangeSet id value}
 
+-- | Smart constructor for $DiffChangeSet
 mkDiffCS :: Map id (ValueOp v) -> DiffChangeSet id v
 mkDiffCS = DiffChangeSet . ChangeSet

--- a/snowdrop-core/src/Snowdrop/Core/Validator/Basic.hs
+++ b/snowdrop-core/src/Snowdrop/Core/Validator/Basic.hs
@@ -7,9 +7,6 @@ module Snowdrop.Core.Validator.Basic
        , StructuralValidationException (..)
        , structuralPreValidator
 
-       , inputsExist
-       , inputsSigned
-       , exampleStateTxValidator
        , redundantIdsPreValidator
        , RedundantIdException (..)
        ) where
@@ -30,9 +27,10 @@ import           Snowdrop.Core.Transaction (TxProof, txBody, txProof)
 import           Snowdrop.Core.Validator.Types (PreValidator (..), Validator, mkValidator)
 import           Snowdrop.Util
 
+-- | Exception type for transaction validation (general failures)
 data TxValidationException
     = PayloadProjectionFailed String Prefix
-    | UnexpectedPayload [Prefix]
+    -- ^ Failed to project payload (from general type to concrete subtype)
     deriving (Show)
 
 instance Buildable TxValidationException where
@@ -43,14 +41,19 @@ instance Buildable TxValidationException where
                %build%", got prefix: "%build)
               tx
               p
-        UnexpectedPayload p -> bprint ("Unexpected payload, prefixes: "%listF ", " build) p
 
+-- | Helper, which can be used for a validator to specify success case.
 valid :: (Monoid a, Monad m) => m a
 valid = pure mempty
 
+-- | Helper, which can be used for a validator to specify conditional success case.
+-- Error will be returned iff the given boolean is $False.
 validateIff :: forall e e1 m a . (Monoid a, MonadError e m, HasReview e e1) => e1 -> Bool -> m a
 validateIff e1 = bool (throwLocalError e1) valid
 
+-- | Helper, which can be used for a validator to specify conditional success case.
+-- Error value is determined for a given element of container and is returned only
+-- if check for the element results in $False.
 validateAll
     :: (Foldable f, MonadError e m, Container (f a))
     => (Element (f a) -> e)
@@ -63,9 +66,12 @@ validateAll ex p ls = maybe (pure ()) (throwError . ex) (find (not . p) ls)
 -- Structural validator
 ---------------------------
 
+-- | Exception type for structural validation ($structuralPreValidator).
 data StructuralValidationException id
     = DpRemoveDoesntExist id
+    -- ^ Id is expected to exist in state, but doesn't.
     | DpAddExist id
+    -- ^ Id is expected to be absent in state, but exists.
     deriving (Show)
 
 instance Buildable id => Buildable (StructuralValidationException id) where
@@ -94,11 +100,14 @@ csNewNotExist = PreValidator $ \tx -> do
     mp <- query ks
     validateAll (inj . DpAddExist) (not . flip M.member mp) ks
 
+-- | Structural validation checks whether the ids which are to be removed
+-- (or to be modified) exist in state and vice versa.
 structuralPreValidator
     :: (Ord id, HasException e (StructuralValidationException id))
     => PreValidator e id value ctx txtype
 structuralPreValidator = csRemoveExist <> csNewNotExist
 
+-- | Exception type for $redundantIdsPreValidator.
 data RedundantIdException = RedundantIdException (NonEmpty Prefix)
     deriving (Show, Generic)
 
@@ -106,6 +115,7 @@ instance Buildable RedundantIdException where
     build (RedundantIdException pref) =
         bprint ("encountered unexpected prefixes: "%listF ", " build) (toList pref)
 
+-- | Redundant id validation asserts that transaction contains no keys with unexpected prefixes.
 redundantIdsPreValidator
     :: forall e id txtype value ctx.
     ( IdSumPrefixed id
@@ -149,8 +159,8 @@ inputsSigned = PreValidator $ \tx -> do
     ins <- query inRefs
     validateIff InputNotSigned (all (($ proof) . fst) ins)
 
-exampleStateTxValidator :: Ord id => Validator GlobalError id ((TxProof txtype) -> Bool, value) ctx '[txtype]
-exampleStateTxValidator = mkValidator [inputsExist, inputsSigned]
+_exampleStateTxValidator :: Ord id => Validator GlobalError id ((TxProof txtype) -> Bool, value) ctx '[txtype]
+_exampleStateTxValidator = mkValidator [inputsExist, inputsSigned]
 
 ---------------------------
 -- HasReview instances

--- a/snowdrop-execution/src/Snowdrop/Execution/Mempool/Core.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/Mempool/Core.hs
@@ -19,10 +19,9 @@ import           Control.Lens (lens)
 import           Data.Default (Default (..))
 
 import           Snowdrop.Core (CSMappendException (..), ChgAccum, ChgAccumCtx,
-                                ChgAccumModifier (..), ERoComp, ERwComp, SomeTx,
-                                StateModificationException, StatePException, StateTx (..), Undo,
-                                Validator, applySomeTx, liftERoComp, modifyRwCompChgAccum,
-                                runValidator)
+                                ChgAccumModifier (..), ERoComp, ERwComp, SomeTx, StatePException,
+                                StateTx (..), Undo, Validator, applySomeTx, liftERoComp,
+                                modifyRwCompChgAccum, runValidator)
 import           Snowdrop.Execution.DbActions (DbAccessActions)
 import           Snowdrop.Execution.IOExecutor (IOCtx, runERwCompIO)
 import           Snowdrop.Util
@@ -77,8 +76,7 @@ newtype Mempool id value chgAccum rawtx = Mempool
 defaultMempoolConfig
     :: forall e id value ctx txtypes rawtx .
     ( HasExceptions e [
-          StateModificationException id
-        , StatePException
+          StatePException
         , CSMappendException id
         ]
     , Ord id

--- a/snowdrop-util/src/Snowdrop/Util/Helpers.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Helpers.hs
@@ -7,7 +7,6 @@ module Snowdrop.Util.Helpers
        , eitherToVerRes
        , verResToEither
        , runExceptTV
-       , WithSignature (..)
        , propagateSecondF
        , PublicKey
        , Signature
@@ -21,12 +20,19 @@ import           Formatting (bprint, build, (%))
 
 import           Snowdrop.Util.Prism.Class
 
+-- | Data family to specify a public key type for a given signature scheme type
 data family PublicKey sigScheme :: *
+-- | Data family to specify a signature type for a given signature scheme type
 data family Signature sigScheme a :: *
 
+-- | Type class, providing capability to verify signatures
+-- (made within some public-key signature scheme, represented by type @sigScheme@)
 class VerifySign sigScheme a where
+    -- | Verify signature of the supplied data which is assumed to be made by a given public key
     verifySignature :: PublicKey sigScheme -> a -> Signature sigScheme a -> Bool
 
+-- | Helper data type to hold data along with its signature
+-- and a public key corresponding to the signature.
 data Signed sigScheme msg = Signed
     { message   :: msg
     , publicKey :: PublicKey sigScheme
@@ -53,13 +59,47 @@ instance (Buildable (PublicKey sigScheme),
         -- in witnesses, and witness is always coupled with related transaction.
         bprint ("signature (pubkey="%(build)%", signature="%(build)%")") pk sig
 
+-- | Type class which allows to get an instance of some enum data type @s@,
+-- specified for a given value @a@.
+--
+-- Usage pattern is as follows:
+--
+-- @
+-- data MyId = MyId1 | MyId2
+-- data HerId = HerId
+--
+-- data AllIds = AMyId MyId | AHerId HerId
+--
+-- instance Enum AllIds where
+--     toEnum x
+--         | x < fromEnum (maxBound @MyId) = AMyId $ toEnum x
+--         | rest < fromEnum (maxBound @HerId) = AHerId $ toEnum rest
+--         | otherwise  = error "invalid int"
+--       where
+--         rest = x - fromEnum (maxBound @MyId)
+--     fromEnum (AMyId s)      = fromEnum s
+--     fromEnum (AHerId HerId) = maxBound @MyId
+--
+-- instance IdStorage AllIds MyId
+-- instance IdStorage AllIds HerId
+--
+-- deriveView withInjProj ''AllIds
+--
+-- -- Integer corresponding to MyId2:
+-- myId2 :: Int
+-- myId2 = getId (Proxy @AllIds) MyId2
+-- @
+--
+-- The type class allows to get an unique integer for any concrete id,
+-- which can be further used for instance for indexing components of database.
 class (HasPrism s a, Enum s) => IdStorage s a
 
+-- | Get integer index for a given id
 getId :: forall ids i . IdStorage ids i => Proxy ids -> i -> Int
 getId _ i = fromEnum (inj i :: ids)
 
--- to avoid orphan instance for Either and change definition of Monoid for Either
-
+-- | Data type, similar to `Either` which provides instances of $Semigroup and $Monoid,
+-- well suited for error handling.
 data VerRes e a = VErr e | VRes a
     deriving (Show, Eq)
 
@@ -72,22 +112,20 @@ instance (Monoid a, Semigroup a) => Monoid (VerRes e a) where
     mempty = VRes mempty
     mappend = (<>)
 
+-- | Convert value of type $Either to type $VerRes
 eitherToVerRes :: Either e a -> VerRes e a
 eitherToVerRes (Right x) = VRes x
 eitherToVerRes (Left e)  = VErr e
 
+-- | Convert value of type $VerRes to type $Either
 verResToEither :: VerRes e a -> Either e a
 verResToEither (VRes x) = Right x
 verResToEither (VErr e) = Left e
 
+-- | Helper to run $ExceptT in order to obtain $VerRes
 runExceptTV :: Monad m => ExceptT e m a -> m (VerRes e a)
 runExceptTV = fmap eitherToVerRes . runExceptT
 
-data WithSignature sigScheme a = WithSignature
-    { wsSignature :: Signature sigScheme a
-    , wsPublicKey :: PublicKey sigScheme
-    , wsBody      :: a
-    }
-
+-- | Simple helper which is equivallent to expression @\(fa, b) -> (,b) <$> fa@
 propagateSecondF :: Functor f => (f a, b) -> f (a, b)
 propagateSecondF (fa, b) = (,b) <$> fa

--- a/snowdrop-util/src/Snowdrop/Util/Logging.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Logging.hs
@@ -44,24 +44,14 @@ import qualified Data.HashMap.Strict as HM
 import qualified System.Console.ANSI as Term
 import qualified System.Wlog as LW
 
--- Copied from Disciplina:
-
-{- | Conventional "ReaderT over IO" monad stack.
-
-Lootbox bases on 'caps' library which allows the only 'ReaderT' instance for
-used typeclasses, e.g.
-@instance (r ~ Capabilities caps) => MonadLogging (ReaderT r IO)@.
-To avoid instances overlapping, we use this wrapper.
-
-This also allows us to remorselessly define one global
-@instance HasLens Smth ctx Smth => MonadSmth (RIO ctx)@ per every @Smth@.
--}
+-- | Conventional RIO monad, being used as a base monad for logging in Snowdrop
 newtype RIO ctx a = RIO (ReaderT ctx IO a)
     deriving (Functor, Applicative, Monad, MonadIO, MonadReader ctx,
               MonadThrow, MonadCatch, MonadMask, MonadBase IO)
 
 deriving instance MonadBase IO (RIO ctx) => MonadBaseControl IO (RIO ctx)
 
+-- | Executor for $RIO monad
 runRIO :: MonadIO m => ctx -> RIO ctx a -> m a
 runRIO ctx (RIO act) = liftIO $ runReaderT act ctx
 
@@ -72,12 +62,15 @@ instance (HasLens LoggingIO ctx LoggingIO) => MonadLogging (RIO ctx) where
 instance (HasLens LoggingIO ctx LoggingIO) => ModifyLogName (RIO ctx) where
     modifyLogNameSel = Rio.defaultModifyLogNameSel
 
+-- | Default execution monad for Snowdrop's execution code.
+-- Provides lootbox's logging.
 type ExecM = RIO LoggingIO
 
 ----------------------------------------------------------------------------
 -- Configuration and initiation
 ----------------------------------------------------------------------------
 
+-- Default logging config for lootbox's logging.
 defaultLogCfg :: LW.LoggerConfig
 defaultLogCfg = LW.productionB & LW.lcTermSeverityOut .~ Just mempty
                                & LW.lcTermSeverityErr .~ Just LW.allSeverities
@@ -100,8 +93,7 @@ defaultLogCfg = LW.productionB & LW.lcTermSeverityOut .~ Just mempty
         , (LW.LoggerName "Client", mkTree "Client.log")
         ]
 
-
--- TODO: finalise config from `ConfigPart`s
+-- | Helper to execute some action within $ExecM monad
 withLogger :: Maybe FilePath -> ExecM () -> IO ()
 withLogger mConfigPath action = do
     cfg <- case mConfigPath of


### PR DESCRIPTION
- [x] Document Snowdrop.Core.ChangeSet.Type
- [x] Document Snowdrop.Core.ChangeSet.ValueOp
- [x] Document Snowdrop.Core.ERoComp.Helpers
- [x] Document Snowdrop.Core.ERwComp
- [x] Note about `Expander` in Snowdrop.Core.Expander
- [x] Comment `SValue`, `mkPartialStateTx` and `selectKeyValueCS` in Snowdrop.Core.Transaction
- [x] Document Snowdrop.Core.Validator.Basic
- [x] Document Snowdrop.Core.Validator.Types
- [x] Document Snowdrop.Util.Helpers
- [x] Document Snowdrop.Util.Logging
- [x] Move comments from Snowdrop.Block.Application to docs (?)
- [x] Add comments in Snowdrop.Block.Fork, uncomment `findLCA` function
- [x] Document Snowdrop.Block.Types
- [ ] Comment `expandUnionRawTxs` in Snowdrop.Execution.Expand, probably move `expandRawTxs` comments to docs
- [ ] Document Snowdrop.Execution.IOExecutor
- [ ] Document Snowdrop.Execution.Restrict
- [ ] Add comments to Snowdrop.Execution.DbActions.AVLp
- [ ] Document Snowdrop.Execution.DbActions.Composite
- [ ] Document Snowdrop.Execution.DbActions.Simple
- [ ] Document Snowdrop.Execution.Mempool.Core
- [ ] Document Snowdrop.Execution.Mempool.Logic