### PR TITLE
[SD-176] Split DbAccess

### DIFF
--- a/snowdrop-block/src/Snowdrop/Block/Fork.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Fork.hs
@@ -41,7 +41,7 @@ data ForkVerResult blkType
     | RejectFork
     -- ^ Fork verification decision is to reject given fork.
 
--- | Exception type for $verifyFork.
+-- | Exception type for 'verifyFork'.
 data ForkVerificationException blkType
     = BlocksNotConsistent
     -- ^ Chain of blocks is not self-consistent: either integrity berification of one of blocks failed

--- a/snowdrop-block/src/Snowdrop/Block/State.hs
+++ b/snowdrop-block/src/Snowdrop/Block/State.hs
@@ -10,8 +10,6 @@ module Snowdrop.Block.State
 
 import           Universum
 
-import qualified Data.ByteString as BS
-import           Data.Default (def)
 import           Data.Default (Default)
 import qualified Data.Map as M
 import qualified Data.Text.Buildable
@@ -20,11 +18,12 @@ import           Snowdrop.Block.Configuration (BlkConfiguration (..))
 import           Snowdrop.Block.StateConfiguration (BlkStateConfiguration (..))
 import           Snowdrop.Block.Types (Block (..), BlockHeader, BlockRef, BlockUndo, Blund (..),
                                        CurrentBlockRef (..), Payload, RawBlk, RawPayload)
-import           Snowdrop.Core (CSMappendException (..), ChangeSet (..), ChgAccum, ChgAccumCtx,
-                                ChgAccumModifier (..), ERwComp, HasKeyValue, IdSumPrefixed (..),
-                                SomeTx, StatePException (..), StateTx (..), Undo (..), Validator,
-                                ValueOp (..), applySomeTx, liftERoComp, mappendChangeSet,
-                                modifyRwCompChgAccum, queryOne, queryOneExists, runValidator)
+import           Snowdrop.Core (CSMappendException (..), ChangeSet (..), ChgAccum,
+                                ChgAccumCtx (CAInitialized), DbAccessU, ERwComp, HasKeyValue,
+                                IdSumPrefixed (..), SomeTx, StatePException (..), StateTx (..),
+                                Validator, ValueOp (..), applySomeTx, computeUndo, convertEffect,
+                                getCAOrDefault, liftERoComp, modifyAccum, modifyAccumOne,
+                                modifyAccumUndo, queryOne, queryOneExists, runValidator)
 import           Snowdrop.Execution (ProofNExp (..), RestrictCtx, RestrictionInOutException,
                                      expandUnionRawTxs)
 import           Snowdrop.Util
@@ -55,8 +54,7 @@ data TipValue blockRef = TipValue {unTipValue :: Maybe blockRef}
 inmemoryBlkStateConfiguration
   :: forall blkType e id value rawTx txtypes ctx .
     ( HasKeyValue id value TipKey (TipValue (BlockRef blkType))
-    , HasKeyValue id value (BlockRef blkType) (Blund (BlockHeader blkType) (RawPayload blkType) (Undo id value))
-    , BlockUndo blkType ~ Undo id value
+    , HasKeyValue id value (BlockRef blkType) (Blund (BlockHeader blkType) (RawPayload blkType) (BlockUndo blkType))
     , HasExceptions e
         [ StatePException
         , BlockStateException id
@@ -76,7 +74,7 @@ inmemoryBlkStateConfiguration
     -> Validator e id value ctx txtypes
     -> (rawTx -> SomeData (ProofNExp e id value ctx rawTx) (RContains txtypes))
     -> (RawBlk blkType -> [SomeTx id value (RContains txtypes)] -> Block (BlockHeader blkType) (Payload blkType))
-    -> BlkStateConfiguration blkType (ERwComp e id value ctx (ChgAccum ctx))
+    -> BlkStateConfiguration blkType (ERwComp e (DbAccessU (ChgAccum ctx) (BlockUndo blkType) id value) ctx (ChgAccum ctx))
 inmemoryBlkStateConfiguration cfg validator mkProof mkBlock =
     BlkStateConfiguration {
       bscConfig = cfg
@@ -84,28 +82,31 @@ inmemoryBlkStateConfiguration cfg validator mkProof mkBlock =
           blkPayload <- liftERoComp $ expandUnionRawTxs mkProof (gett rawBlock)
           pure (mkBlock rawBlock blkPayload)
     , bscApplyPayload = \(gett @_ @[SomeTx id value (RContains txtypes)] -> txs) -> do
-          undos <- forM txs $ \tx -> do
-                      liftERoComp $ applySomeTx (runValidator validator) tx
-                      modifyRwCompChgAccum (CAMChange $ applySomeTx txBody tx)
-          let mergeUndos (Undo cs1 _) (Undo cs2 sn2) = flip Undo sn2 <$> mappendChangeSet cs1 cs2
-          case reverse undos of
-              []     -> pure $ Undo def BS.empty
-              f:rest -> either throwLocalError pure $ foldM mergeUndos f rest
-    , bscApplyUndo = void . modifyRwCompChgAccum . CAMRevert
+          (mNewSt, undo) <- liftERoComp $ do
+              OldestFirst accs <- convertEffect $ modifyAccum (OldestFirst $ map (applySomeTx txBody) txs)
+              convertEffect $ mconcat $ flip map (zip accs txs) $ \(acc, tx) ->
+                  local ( lensFor .~ CAInitialized @ctx acc ) $ applySomeTx (runValidator validator) tx
+              case accs of
+                (a : rest) -> let lastAcc = last (a :| rest)
+                               in (Just lastAcc,) <$> computeUndo @_ @id @value lastAcc
+                _          -> (Nothing,) <$> (asks (getCAOrDefault @ctx . gett) >>= computeUndo @_ @id @value)
+          undo <$ whenJust mNewSt (modify . flip sett)
+    , bscApplyUndo = liftERoComp . modifyAccumUndo @_ @id @value . pure >=> modify . flip sett
     , bscStoreBlund = \blund -> do
           let blockRef = unCurrentBlockRef $ bcBlockRef cfg (blkHeader $ buBlock blund)
-          let chg = ChangeSet $ M.singleton (inj $ blockRef) (New $ inj blund)
-          void $ modifyRwCompChgAccum $ CAMChange chg
-    , bscRemoveBlund = \blockRef ->
-        void $ modifyRwCompChgAccum $ CAMRevert $ Undo (ChangeSet $ M.singleton (inj blockRef) Rem) BS.empty
-    , bscGetBlund = liftERoComp . queryOne
-    , bscBlockExists = liftERoComp . queryOneExists
-    , bscGetTip = liftERoComp (queryOne TipKey)
+          let (chg :: ChangeSet id value) = ChangeSet $ M.singleton (inj $ blockRef) (New $ inj blund)
+          liftERoComp (modifyAccumOne chg) >>= modify . flip sett
+    , bscRemoveBlund = \blockRef -> do
+          let (chg :: ChangeSet id value) = ChangeSet $ M.singleton (inj blockRef) Rem
+          liftERoComp (modifyAccumOne chg) >>= modify . flip sett
+    , bscGetBlund = liftERoComp . queryOne @id @_ @value
+    , bscBlockExists = liftERoComp . queryOneExists @id @_ @value
+    , bscGetTip = liftERoComp (queryOne @id @_ @value TipKey)
                     >>= maybe (throwLocalError @(BlockStateException id) TipNotFound) (pure . unTipValue)
     , bscSetTip = \newTip' -> do
           let newTip = inj $ TipValue newTip'
           let tipChg = \cons -> ChangeSet $ M.singleton (inj TipKey) (cons newTip)
-          oldTipMb <- liftERoComp $ queryOne TipKey
-          -- TODO check that tip corresponds to blund storage
-          void . modifyRwCompChgAccum . CAMChange . tipChg $ maybe New (const Upd) oldTipMb
+          oldTipMb <- liftERoComp $ queryOne @id @_ @value TipKey
+          let (chg :: ChangeSet id value) = tipChg $ maybe New (const Upd) oldTipMb
+          liftERoComp (modifyAccumOne chg) >>= modify . flip sett
     }

--- a/snowdrop-block/src/Snowdrop/Block/Types.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Types.hs
@@ -50,7 +50,7 @@ data Block header payload = Block
     , blkPayload :: payload
     } deriving (Show, Eq, Ord, Generic)
 
--- TODO consider removing HasBlock type class and using $HasGetter in its stead
+-- TODO consider removing HasBlock type class and using 'HasGetter' in its stead
 
 -- | Getter type class for a block
 class HasBlock header payload b where
@@ -66,7 +66,7 @@ data Blund header payload undo = Blund
     , buUndo  :: undo
     } deriving (Eq, Ord, Show, Generic)
 
--- | $Blund type, parametrized with raw payload.
+-- | 'Blund' type, parametrized with raw payload.
 type RawBlund blkType =
     (Blund (BlockHeader blkType) (RawPayload blkType) (BlockUndo blkType))
 

--- a/snowdrop-core/src/Snowdrop/Core/ERoComp/Helpers.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERoComp/Helpers.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DeriveFunctor       #-}
-{-# LANGUAGE InstanceSigs        #-}
 {-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -90,13 +89,6 @@ modifyAccumOne cs =
   where
     head' []    = error "modifyAccumOne: unexpected empty effect execution result"
     head' (a:_) = a
-
---     = DbModifyAccumUndo
---         (NewestFirst [] undo)
---         (Either (CSMappendException id) chgAccum -> res)
---     | DbComputeUndo
---         (ChangeSet id value)
---         (Either (CSMappendException id) undo -> res)
 
 -- | Creates a DbComputeUndo operation.
 computeUndo

--- a/snowdrop-core/src/Snowdrop/Core/ERoComp/Helpers.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERoComp/Helpers.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DeriveFunctor       #-}
+{-# LANGUAGE InstanceSigs        #-}
 {-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -14,28 +15,35 @@ module Snowdrop.Core.ERoComp.Helpers
        , querySet
        , queryOne
        , queryOneExists
-       , modifyAccum
 
-       , withModifiedAccumCtx
+       , computeUndo
+       , modifyAccumUndo
+       , modifyAccum
+       , modifyAccumOne
+
        , initAccumCtx
        , getCAOrDefault
+       , withModifiedAccumCtxOne
+
+       , ConvertEffect (..)
        ) where
 
 import           Universum
 
+import           Control.Monad.Except (MonadError)
+import           Data.Default (Default (def))
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text.Buildable
 
-import           Data.Default (Default (def))
-
-import           Snowdrop.Core.BaseM (effect)
-import           Snowdrop.Core.ChangeSet (CSMappendException (..), ChangeSet (..), Undo)
-import           Snowdrop.Core.ERoComp.Types (ChgAccum, ChgAccumCtx (..), ChgAccumModifier (..),
-                                              DbAccess (..), ERoComp, FoldF (..), Prefix (..),
-                                              StateP, StateR)
+import           Snowdrop.Core.BaseM (BaseM (..), Effectful (..))
+import           Snowdrop.Core.ChangeSet (CSMappendException (..), ChangeSet (..))
+import           Snowdrop.Core.ERoComp.Types (ChgAccum, ChgAccumCtx (..), DbAccess (..),
+                                              DbAccessM (..), DbAccessU (..), ERoComp, ERoCompM,
+                                              ERoCompU, FoldF (..), Prefix (..), StateP, StateR)
 import           Snowdrop.Core.Transaction (HasKeyValue)
 import           Snowdrop.Util
+import qualified Snowdrop.Util as Log
 
 -- | Possible errors throwning from basic functions in ERoComp.
 data StatePException
@@ -58,7 +66,7 @@ deriveIdView withInj ''StatePException
 
 -- | Creates a DbQuery operation.
 query :: forall e id value ctx . StateR id -> ERoComp e id value ctx (StateP id value)
-query req = effect $ DbQuery @(ChgAccum ctx) req id
+query req = effect $ DbQuery req id
 
 -- | Creates a DbIterator operation.
 iterator
@@ -68,15 +76,46 @@ iterator
     -> ((id, value) -> b -> b)
     -> ERoComp e id value ctx b
 iterator prefix e foldf =
-    effect $ DbIterator @(ChgAccum ctx) prefix (FoldF (e, foldf, id))
+    effect $ DbIterator prefix (FoldF (e, foldf, id))
+
+-- | Creates a DbModifyAccum operation.
+modifyAccumOne
+    :: forall e id value ctx .
+      (HasException e (CSMappendException id))
+    => ChangeSet id value
+    -> ERoCompM e id value ctx (ChgAccum ctx)
+modifyAccumOne cs =
+    effect (DbModifyAccum (OldestFirst [cs]) (fmap $ head' . unOldestFirst))
+      >>= either throwLocalError pure
+  where
+    head' []    = error "modifyAccumOne: unexpected empty effect execution result"
+    head' (a:_) = a
+
+--     = DbModifyAccumUndo
+--         (NewestFirst [] undo)
+--         (Either (CSMappendException id) chgAccum -> res)
+--     | DbComputeUndo
+--         (ChangeSet id value)
+--         (Either (CSMappendException id) undo -> res)
+
+-- | Creates a DbComputeUndo operation.
+computeUndo
+  :: forall e id value undo ctx . (HasException e (CSMappendException id))
+  => ChgAccum ctx -> ERoCompU e id value undo ctx undo
+computeUndo chgAcc = effect (DbComputeUndo @_ @_ @id @value chgAcc id) >>= either throwLocalError pure
+
+modifyAccumUndo
+  :: forall e id value undo ctx . (HasException e (CSMappendException id))
+  => NewestFirst [] undo -> ERoCompU e id value undo ctx (ChgAccum ctx)
+modifyAccumUndo undos = effect (DbModifyAccumUndo @_ @_ @id @value undos id) >>= either throwLocalError pure
 
 -- | Creates a DbModifyAccum operation.
 modifyAccum
     :: forall e id value ctx .
-       ChgAccum ctx
-    -> ChgAccumModifier id value
-    -> ERoComp e id value ctx (Either (CSMappendException id) (ChgAccum ctx, Undo id value))
-modifyAccum chgAccum chgSet = effect $ DbModifyAccum chgAccum chgSet id
+      (HasException e (CSMappendException id))
+    => OldestFirst [] (ChangeSet id value)
+    -> ERoCompM e id value ctx (OldestFirst [] (ChgAccum ctx))
+modifyAccum css = effect (DbModifyAccum css id) >>= either throwLocalError pure
 
 -- | Like @query@, however, inject @id'@ to @id@ before a query and project @value@ to @value'@
 -- after the query.
@@ -127,7 +166,7 @@ iteratorFor
     -> ((id', value') -> b -> b)
     -> ERoComp e id value ctx b
 iteratorFor prefix e foldf = do
-    res <- effect $ DbIterator @(ChgAccum ctx) @id @value prefix (FoldF (e1, foldf1, id))
+    res <- effect $ DbIterator @id @value prefix (FoldF (e1, foldf1, id))
     case res of
         Left ex -> throwLocalError ex
         Right x -> pure x
@@ -143,32 +182,13 @@ iteratorFor prefix e foldf = do
 --- Functions to modify computation's context
 ----------------------------------------------------
 
--- | Runs computation with modified Change Accumulator from @ctx@.
--- Passed ChangeSet will be appended to the accumulator as a modification.
-withModifiedAccumCtx
-    :: forall e id value ctx a .
-    ( HasException e (CSMappendException id)
-    , HasLens ctx (ChgAccumCtx ctx)
-    , Default (ChgAccum ctx)
-    )
-    => ChangeSet id value
-    -> ERoComp e id value ctx a
-    -> ERoComp e id value ctx a
-withModifiedAccumCtx chgSet comp = do
-    ctxAcc <- getCAOrDefault @ctx . gett <$> ask
-    newAccOrErr <- modifyAccum ctxAcc $ CAMChange chgSet
-    case newAccOrErr of
-        Left err   -> throwLocalError err
-        Right (acc', _undo) ->
-            local ( lensFor @ctx @(ChgAccumCtx ctx) .~ CAInitialized @ctx acc' ) comp
-
 -- | Runs computation with specified initial Change Accumulator.
 initAccumCtx
-    :: forall e id value ctx a .
+    :: forall e eff ctx a .
     (HasException e StatePException, HasLens ctx (ChgAccumCtx ctx))
     => ChgAccum ctx
-    -> ERoComp e id value ctx a
-    -> ERoComp e id value ctx a
+    -> BaseM e eff ctx a
+    -> BaseM e eff ctx a
 initAccumCtx acc' comp = do
     gett @_ @(ChgAccumCtx ctx) <$> ask >>= \case
         CAInitialized _ -> throwLocalError ChgAccumCtxUnexpectedlyInitialized
@@ -179,3 +199,58 @@ initAccumCtx acc' comp = do
 getCAOrDefault :: Default (ChgAccum ctx) => ChgAccumCtx ctx -> ChgAccum ctx
 getCAOrDefault CANotInitialized   = def
 getCAOrDefault (CAInitialized cA) = cA
+
+class ConvertEffect e ctx eff1 eff2 where
+    convertEffect :: BaseM e eff1 ctx a -> BaseM e eff2 ctx a
+
+newtype DbAccessT (eff1 :: * -> * -> * -> *) (eff2 :: * -> * -> * -> *) m a = DbAccessT { runDbAccessT :: m a }
+    deriving ( Functor, Applicative, Monad, MonadError e
+             , MonadReader ctx, Log.MonadLogging, Log.ModifyLogName)
+
+instance (Effectful (DbAccessM chgAccum id value) m)
+    => Effectful (DbAccess id value)
+                 (DbAccessT DbAccess (DbAccessM chgAccum) m) where
+    effect da = DbAccessT $ effect (DbAccess @chgAccum da)
+
+instance (Effectful (DbAccessU chgAccum undo id value) m)
+    => Effectful (DbAccess id value)
+                 (DbAccessT DbAccess (DbAccessU chgAccum undo) m) where
+    effect da = DbAccessT $ effect (DbAccessM @chgAccum @undo $ DbAccess da)
+
+instance (Effectful (DbAccessU chgAccum undo id value) m)
+    => Effectful (DbAccessM chgAccum id value)
+                 (DbAccessT (DbAccessM chgAccum) (DbAccessU chgAccum undo) m) where
+    effect da = DbAccessT $ effect (DbAccessM @chgAccum @undo da)
+
+instance ConvertEffect e ctx (DbAccess id value) (DbAccessM chgAccum id value) where
+    convertEffect (BaseM action) = BaseM ( runDbAccessT @DbAccess @(DbAccessM chgAccum) action )
+
+instance ConvertEffect e ctx (DbAccessM chgAccum id value) (DbAccessU chgAccum undo id value) where
+    convertEffect (BaseM action) = BaseM ( runDbAccessT @(DbAccessM chgAccum) @(DbAccessU chgAccum undo) action )
+
+instance ConvertEffect e ctx (DbAccess id value) (DbAccessU chgAccum undo id value) where
+    convertEffect (BaseM action) = BaseM ( runDbAccessT @DbAccess @(DbAccessU chgAccum undo) action )
+
+instance ConvertEffect e ctx (DbAccessU chgAccum undo id value) (DbAccessU chgAccum undo id value) where
+    convertEffect = id
+
+instance ConvertEffect e ctx (DbAccessM chgAccum id value) (DbAccessM chgAccum id value) where
+    convertEffect = id
+
+instance ConvertEffect e ctx (DbAccess id value) (DbAccess id value) where
+    convertEffect = id
+
+-- | Runs computation with modified Change Accumulator from @ctx@.
+-- Passed ChangeSet will be appended to the accumulator as a modification.
+withModifiedAccumCtxOne
+    :: forall e id value ctx a .
+    ( HasException e (CSMappendException id)
+    , HasLens ctx (ChgAccumCtx ctx)
+    , Default (ChgAccum ctx)
+    )
+    => ChangeSet id value
+    -> ERoCompM e id value ctx a
+    -> ERoCompM e id value ctx a
+withModifiedAccumCtxOne chgSet comp = do
+    acc' <- modifyAccumOne chgSet
+    local ( lensFor @ctx @(ChgAccumCtx ctx) .~ CAInitialized @ctx acc' ) comp

--- a/snowdrop-core/src/Snowdrop/Core/ERoComp/Types.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERoComp/Types.hs
@@ -38,9 +38,11 @@ type StateR id = Set id
 type StateP id value = Map id value
 
 -- | Datatype describing read only interface for access to a state:
---   * Simple query, iteration
+--
+-- * Simple query, iteration
+--
 -- Type variables @id@, @value@ describe types of key and value of key-value storage.
--- Variable @res denotes result of $DbAccess execution.
+-- Variable @res@ denotes result of 'DbAccess' execution.
 data DbAccess id value res
     = DbQuery (StateR id) (StateP id value -> res)
     -- ^ Request to state.
@@ -53,13 +55,16 @@ data DbAccess id value res
     -- The second one is used to accumulate entries during iteration.
 
 -- | Datatype describing read only interface for access to a state:
---   * Simple query, iteration
---   * Ability to convert sequence of change sets to sequence of change accumulators
--- Monad in which $DbAccessM is executed is expected to provide method
--- to use change accumulator in order to alter accesses done with $DbAccess.
+--
+-- * Simple query, iteration
+-- * Ability to convert sequence of change sets to sequence of change accumulators
+--
+-- Monad in which 'DbAccessM' is executed is expected to provide method
+-- to use change accumulator in order to alter accesses done with 'DbAccess'.
+--
 -- Type variables @id@, @value@ describe types of key and value of key-value storage,
 -- @chgAccum@ is in-memory accumulator of changes.
--- Variable @res denotes result of $DbAccessM execution.
+-- Variable @res@ denotes result of 'DbAccessM' execution.
 data DbAccessM chgAccum id value res
     = DbModifyAccum
         (OldestFirst [] (ChangeSet id value))
@@ -70,27 +75,29 @@ data DbAccessM chgAccum id value res
     -- (and modify it in the way corresponding change set prescribes).
     -- This action doesn't necessarily imply an explicit access to state
     -- (and might be a pure operation, e.g. for storage types that
-    -- use $SumChangeSet as change accumulator).
+    -- use 'SumChangeSet' as change accumulator).
     -- Some storage types though do require an access to internal state (e.g. AVL+ storage)
     -- due to more complicated structure of their respective change accumulator.
     --
     -- Operation's name "modify accumulator" refers to the fact that
-    -- $DbAccessM is typically executed in monad with read access to internal
+    -- 'DbAccessM' is typically executed in monad with read access to internal
     -- change accumulator which modifies the actual state. To perform the
-    -- $DbModifyAccum operation underlying monad is required to read this
+    -- 'DbModifyAccum' operation underlying monad is required to read this
     -- internal change accumulator and apply sequence of change sets to it.
     | DbAccess (DbAccess id value res)
     -- ^ Object for simple access to state (query, iteration).
 
 -- | Datatype describing read only interface for access to a state:
---   * Simple query, iteration
---   * Ability to convert sequence of change sets to sequence of change accumulators
---   * Ability to compute undo for a given change accumulator
---   * Ability to convert sequence of undo objects to a change accumulator
+--
+-- * Simple query, iteration
+-- * Ability to convert sequence of change sets to sequence of change accumulators
+-- * Ability to compute undo for a given change accumulator
+-- * Ability to convert sequence of undo objects to a change accumulator
+--
 -- Type variables @id@, @value@ describe types of key and value of key-value storage,
 -- @chgAccum@ is in-memory accumulator of changes,
 -- @undo@ is an object allowing to revert changes proposed by some @chgAccum@.
--- Variable @res denotes result of $DbAccessU execution.
+-- Variable @res@ denotes result of 'DbAccessU' execution.
 data DbAccessU chgAccum undo id value res
     = DbModifyAccumUndo
         (NewestFirst [] undo)
@@ -102,14 +109,14 @@ data DbAccessU chgAccum undo id value res
     -- sequence of undo objects).
     -- This action doesn't necessarily imply an explicit access to state
     -- (and might be a pure operation, e.g. for storage types that
-    -- use $SumChangeSet as change accumulator).
+    -- use 'SumChangeSet' as change accumulator).
     -- Some storage types though do require an access to internal state (e.g. AVL+ storage)
     -- due to more complicated structure of their respective change accumulator.
     --
     -- Operation's name "modify accumulator with undo" refers to the fact that
-    -- $DbAccessU is typically executed in monad with read access to internal
+    -- 'DbAccessU' is typically executed in monad with read access to internal
     -- change accumulator which modifies the actual state. To perform the
-    -- $DbModifyAccumUndo operation underlying monad is required to read this
+    -- 'DbModifyAccumUndo' operation underlying monad is required to read this
     -- internal change accumulator and apply sequence of change sets to it.
     | DbComputeUndo
         chgAccum
@@ -121,7 +128,7 @@ data DbAccessU chgAccum undo id value res
     --
     -- This action doesn't necessarily imply an explicit access to state
     -- (and might be a pure operation, e.g. for storage types that
-    -- use $SumChangeSet as change accumulator).
+    -- use 'SumChangeSet' as change accumulator).
     -- Some storage types though do require an access to internal state (e.g. AVL+ storage)
     -- due to more complicated structure of their respective change accumulator.
     | DbAccessM (DbAccessM chgAccum id value res)

--- a/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
@@ -5,6 +5,7 @@ module Snowdrop.Core.ERwComp
        , runERwComp
        -- , modifyRwCompChgAccum
        , liftERoComp
+       , convertERwComp
        ) where
 
 import           Universum
@@ -50,3 +51,7 @@ liftERoComp
     -> ERwComp e eff2 ctx s a
 liftERoComp comp =
     gets (gett @_ @(ChgAccum ctx)) >>= ERwComp . lift . flip initAccumCtx (convertEffect comp)
+
+
+convertERwComp :: (BaseM e eff1 ctx (a, s) -> BaseM e eff2 ctx (a, s)) -> ERwComp e eff1 ctx s a -> ERwComp e eff2 ctx s a
+convertERwComp f (ERwComp (StateT act)) = ERwComp $ StateT $ \s -> f (act s)

--- a/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
@@ -3,34 +3,33 @@
 module Snowdrop.Core.ERwComp
        ( ERwComp
        , runERwComp
-       , modifyRwCompChgAccum
+       -- , modifyRwCompChgAccum
        , liftERoComp
        ) where
 
 import           Universum
 
-import           Control.Lens ((.=))
 import           Control.Monad.Except (MonadError)
 
-import           Snowdrop.Core.ChangeSet (CSMappendException (..), Undo)
-import           Snowdrop.Core.ERoComp (ChgAccum, ChgAccumCtx (..), ChgAccumModifier, ERoComp,
-                                        StatePException (..), initAccumCtx, modifyAccum)
+import           Snowdrop.Core.BaseM (BaseM)
+import           Snowdrop.Core.ERoComp (ChgAccum, ChgAccumCtx (..), ConvertEffect (..),
+                                        StatePException (..), initAccumCtx)
 import           Snowdrop.Util
 
 -- | StateT over ERoComp.
 -- ERoComp can be lifted to ERwComp with regarding a current state.
-newtype ERwComp e id value ctx s a = ERwComp { unERwComp :: StateT s (ERoComp e id value ctx) a }
+newtype ERwComp e eff ctx s a = ERwComp { unERwComp :: StateT s (BaseM e eff ctx) a }
     deriving (Functor, Applicative, Monad, MonadError e, MonadState s)
 
 -- | Run a ERwComp with a passed initial state.
 runERwComp
-    :: forall e id value ctx s a.
+  :: forall e eff ctx s a.
     ( HasException e StatePException
     , HasGetter ctx (ChgAccumCtx ctx)
     )
-    => ERwComp e id value ctx s a
-    -> s
-    -> ERoComp e id value ctx (a, s)
+  => ERwComp e eff ctx s a
+  -> s
+  -> BaseM e eff ctx (a, s)
 runERwComp stComp initS = do
     mChgAccum <- asks (gett @_ @(ChgAccumCtx ctx))
     case mChgAccum of
@@ -41,25 +40,13 @@ runERwComp stComp initS = do
 -- | Lift passed ERoComp to ERwComp.
 -- Set initial state of ERoComp as ChgAccum from state from ERwComp.
 liftERoComp
-    :: forall e id value ctx s a.
+    :: forall e eff2 ctx s eff1 a.
     ( HasException e StatePException
     , HasLens ctx (ChgAccumCtx ctx)
     , HasGetter s (ChgAccum ctx)
+    , ConvertEffect e ctx eff1 eff2
     )
-    => ERoComp e id value ctx a
-    -> ERwComp e id value ctx s a
-liftERoComp comp = gets (gett @_ @(ChgAccum ctx)) >>= ERwComp . lift . flip initAccumCtx comp
-
--- | Mappend passed ChgAccumModifier to ChgAccum part of a state.
-modifyRwCompChgAccum
-    :: forall e id value ctx s .
-    ( HasException e (CSMappendException id)
-    , HasLens s (ChgAccum ctx)
-    )
-    => ChgAccumModifier id value
-    -> ERwComp e id value ctx s (Undo id value)
-modifyRwCompChgAccum chgSet = do
-    chgAcc <- gets (gett @_ @(ChgAccum ctx))
-    newChgAccOrE <- ERwComp $ lift $ modifyAccum chgAcc chgSet
-    flip (either $ ERwComp . throwLocalError) newChgAccOrE $
-      \(chgAcc', undo) -> (lensFor @s @(ChgAccum ctx) .= chgAcc') $> undo
+    => BaseM e eff1 ctx a
+    -> ERwComp e eff2 ctx s a
+liftERoComp comp =
+    gets (gett @_ @(ChgAccum ctx)) >>= ERwComp . lift . flip initAccumCtx (convertEffect comp)

--- a/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
@@ -3,7 +3,6 @@
 module Snowdrop.Core.ERwComp
        ( ERwComp
        , runERwComp
-       -- , modifyRwCompChgAccum
        , liftERoComp
        , convertERwComp
        ) where

--- a/snowdrop-core/src/Snowdrop/Core/Expander.hs
+++ b/snowdrop-core/src/Snowdrop/Core/Expander.hs
@@ -46,9 +46,9 @@ data PreExpander e id value ctx rawTx = PreExpander
 instance Contravariant (PreExpander e id value ctx) where
     contramap g (PreExpander s1 s2 f) = PreExpander s1 s2 (f . g)
 
--- | DiffChangeSet holds changes which one $PreExpander returns
+-- | DiffChangeSet holds changes which one 'PreExpander' returns
 newtype DiffChangeSet id value = DiffChangeSet {unDiffCS :: ChangeSet id value}
 
--- | Smart constructor for $DiffChangeSet
+-- | Smart constructor for 'DiffChangeSet'
 mkDiffCS :: Map id (ValueOp v) -> DiffChangeSet id v
 mkDiffCS = DiffChangeSet . ChangeSet

--- a/snowdrop-core/src/Snowdrop/Core/Transaction.hs
+++ b/snowdrop-core/src/Snowdrop/Core/Transaction.hs
@@ -38,12 +38,12 @@ type family SValue id :: *
 type family TxProof (txtype :: k) :: *
 
 -- | Constraint, ensuring proper value type is used with id type
--- Uses $SValue type family in order to maintain relation.
+-- Uses 'SValue' type family in order to maintain relation.
 type HasKeyValue id val id1 val1 = (HasPrism id id1, HasPrism val val1, SValue id1 ~ val1)
 
 -- | Transaction which modifies state.
 -- There is also RawTx, which is posted on the blockchain.
--- Ideally, RawStateTx and any action which modifies a state can be converted into $StateTx.
+-- Ideally, RawStateTx and any action which modifies a state can be converted into 'StateTx'.
 data StateTx id value (txtype :: *) = StateTx
     { txProof :: TxProof txtype
     , txBody  :: ChangeSet id value
@@ -75,7 +75,7 @@ deriving instance (Ord  (TxProof txtype), Ord  id, Ord  value) => Ord  (StateTx 
 deriving instance (Show (TxProof txtype), Show id, Show value) => Show (StateTx id value txtype)
 deriving instance Generic (StateTx id txtype value)
 
--- | Traverse change set and ensure all keys have the same prefixes, construct $PartialStateTx as result.
+-- | Traverse change set and ensure all keys have the same prefixes, construct 'PartialStateTx' as result.
 -- Throws an error in case of multiple prefixes found in given change set.
 mkPartialStateTx
     :: forall id1 txtype value . Ord id1

--- a/snowdrop-core/src/Snowdrop/Core/Validator/Basic.hs
+++ b/snowdrop-core/src/Snowdrop/Core/Validator/Basic.hs
@@ -47,13 +47,13 @@ valid :: (Monoid a, Monad m) => m a
 valid = pure mempty
 
 -- | Helper, which can be used for a validator to specify conditional success case.
--- Error will be returned iff the given boolean is $False.
+-- Error will be returned iff the given boolean is 'False'.
 validateIff :: forall e e1 m a . (Monoid a, MonadError e m, HasReview e e1) => e1 -> Bool -> m a
 validateIff e1 = bool (throwLocalError e1) valid
 
 -- | Helper, which can be used for a validator to specify conditional success case.
 -- Error value is determined for a given element of container and is returned only
--- if check for the element results in $False.
+-- if check for the element results in 'False'.
 validateAll
     :: (Foldable f, MonadError e m, Container (f a))
     => (Element (f a) -> e)
@@ -66,7 +66,7 @@ validateAll ex p ls = maybe (pure ()) (throwError . ex) (find (not . p) ls)
 -- Structural validator
 ---------------------------
 
--- | Exception type for structural validation ($structuralPreValidator).
+-- | Exception type for structural validation ('structuralPreValidator').
 data StructuralValidationException id
     = DpRemoveDoesntExist id
     -- ^ Id is expected to exist in state, but doesn't.
@@ -107,7 +107,7 @@ structuralPreValidator
     => PreValidator e id value ctx txtype
 structuralPreValidator = csRemoveExist <> csNewNotExist
 
--- | Exception type for $redundantIdsPreValidator.
+-- | Exception type for 'redundantIdsPreValidator'.
 data RedundantIdException = RedundantIdException (NonEmpty Prefix)
     deriving (Show, Generic)
 

--- a/snowdrop-core/src/Snowdrop/Core/Validator/Types.hs
+++ b/snowdrop-core/src/Snowdrop/Core/Validator/Types.hs
@@ -28,7 +28,7 @@ import           Snowdrop.Util (HasGetter, HasPrism (..), RContains)
 newtype PreValidator e id value ctx txtype =
     PreValidator { runPrevalidator :: StateTx id value txtype -> ERoComp e id value ctx () }
 
--- | Alias for $PreValidator constructor
+-- | Alias for 'PreValidator' constructor
 mkPreValidator
     :: (StateTx id value txtype -> ERoComp e id value ctx ())
     -> PreValidator e id value ctx txtype
@@ -48,7 +48,7 @@ instance Ord id => Monoid (PreValidator e id value ctx txtype) where
     mempty = PreValidator $ const (pure ())
     mappend = (<>)
 
--- | Smart constructor for $Validator type
+-- | Smart constructor for 'Validator' type
 mkValidator ::
     Ord id
     => [PreValidator e id value ctx txtype]

--- a/snowdrop-core/test/Test/Snowdrop/Core/Free.hs
+++ b/snowdrop-core/test/Test/Snowdrop/Core/Free.hs
@@ -57,8 +57,8 @@ prop_ercLen = property $ do
         cntJ     = getOperNum erpcRes
     case (cnts, cntJ) of
         (Left _, Left _) -> assert True
-        (Right (Counter q1 i1 m1, Counter q2 i2 m2), Right (Counter q i m)) ->
-            assert (i1 + i2 + m1 + m2 + q1 + q2 == i + q + m)
+        (Right (Counter q1 i1, Counter q2 i2), Right (Counter q i)) ->
+            assert (i1 + i2 + q1 + q2 == i + q)
         _ -> assert False
     -- TODO adjust these tests for JoinExecT as it will be ready
     -- assert (i1 + i2 + max q1 q2 >= i + q)

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/AVLp/Avl.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/AVLp/Avl.hs
@@ -7,6 +7,7 @@ module Snowdrop.Execution.DbActions.AVLp.Avl
        ( AvlHashable
        , KVConstraint
        , RootHash (..)
+       , AvlUndo
        , saveAVL
        , materialize
        , mkAVL
@@ -33,6 +34,8 @@ type KVConstraint k v = (IdSumPrefixed k, Typeable k, Ord k, Show k,
 
 newtype RootHash h = RootHash { unRootHash :: h }
     deriving (Eq, Serialisable)
+
+type AvlUndo = RootHash
 
 saveAVL :: forall h k v m . (AVL.Stores h k v m, MonadCatch m) => AVL.Map h k v -> m (RootHash h)
 saveAVL avl = AVL.save avl $> avlRootHash avl

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/AVLp/Avl.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/AVLp/Avl.hs
@@ -33,7 +33,7 @@ type KVConstraint k v = (IdSumPrefixed k, Typeable k, Ord k, Show k,
                          Serialisable k, Serialisable v, Show v, Eq v)
 
 newtype RootHash h = RootHash { unRootHash :: h }
-    deriving (Eq, Serialisable)
+  deriving (Eq, Serialisable, Show)
 
 type AvlUndo = RootHash
 

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/Composite.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/Composite.hs
@@ -1,22 +1,28 @@
 module Snowdrop.Execution.DbActions.Composite
        (
-         constructCompositeActions
+         constructCompositeDaa
+       , constructCompositeDaaM
+       , constructCompositeDaaU
        , CompositeChgAccum (..)
+       , CompositeUndo (..)
        ) where
 
 import           Universum
 
-import qualified Data.ByteString as BS
 import           Data.Default (Default (def))
 import qualified Data.Map.Strict as M
 import           Data.Reflection (Reifies, reflect)
 import qualified Data.Set as S
 
-import           Snowdrop.Core (ChangeSet (..), ChgAccumModifier (..), IdSumPrefixed (..),
-                                Prefix (..), Undo (..), filterByPrefixPred, filterSetByPrefixPred,
-                                mappendChangeSet)
-
+import           Snowdrop.Core (CSMappendException, ChangeSet (..), IdSumPrefixed (..), Prefix (..),
+                                filterByPrefixPred, filterSetByPrefixPred)
 import           Snowdrop.Execution.DbActions.Types
+import           Snowdrop.Util (NewestFirst (..), OldestFirst (..))
+
+data CompositeUndo undoPrimary undoSecondary ps = CompositeUndo
+    { cuPrimary   :: undoPrimary
+    , cuSecondary :: undoSecondary
+    }
 
 data CompositeChgAccum chgAccumPrimary chgAccumSecondary ps = CompositeChgAccum
     { ccaPrimary   :: chgAccumPrimary
@@ -27,42 +33,79 @@ instance (Default chgAccumPrimary, Default chgAccumSecondary)
         => Default (CompositeChgAccum chgAccumPrimary chgAccumSecondary ps) where
     def = CompositeChgAccum def def
 
-constructCompositeActions
+constructCompositeDaa
     :: forall ps chgAccumPrimary chgAccumSecondary id value m .
-    (Reifies ps (Set Prefix), Ord id, MonadCatch m, IdSumPrefixed id)
+    (Reifies ps (Set Prefix), Ord id, Applicative m, IdSumPrefixed id)
     => DbAccessActions chgAccumPrimary id value m
     -> DbAccessActions chgAccumSecondary id value m
     -> DbAccessActions (CompositeChgAccum chgAccumPrimary chgAccumSecondary ps) id value m
-constructCompositeActions dbaP dbaS =
-    DbAccessActions cGetter cModifyAccum $ \(CompositeChgAccum caP caS) p ->
+constructCompositeDaa dbaP dbaS =
+    DbAccessActions cGetter $ \(CompositeChgAccum caP caS) p ->
         bool (daaIter dbaS caS p) (daaIter dbaP caP p) $ p `S.member` prefixes
   where
-    cModifyAccum (CompositeChgAccum cP cS) chgAccMod = runExceptT $ do
-        (accP, undoP) <- ExceptT $ daaModifyAccum dbaP cP camP
-        (accS, undoS) <- ExceptT $ daaModifyAccum dbaS cS camS
-        (,) (CompositeChgAccum accP accS) <$> mergeUndos undoP undoS
-      where
-        processCS f = bimap f f . splitCS
-        (camP, camS) =
-          case chgAccMod of
-            CAMChange cs         -> processCS CAMChange cs
-            CAMRevert (Undo cs sn) -> processCS (CAMRevert . flip Undo sn) cs
-    mergeUndos (Undo csP snP) (Undo csS snS) =
-      if BS.null snP || BS.null snS
-      then flip Undo (snP `BS.append` snS)
-           <$> (ExceptT $ pure $ csP `mappendChangeSet` csS)
-      else throwM $ DbApplyException "Both undo contain non-empty snapshot in composite actions"
-    splitCS cs = (csP, csS)
-      where
-        csP = filterByPrefixPred (`S.member` prefixes) cs
-        csS = ChangeSet $ changeSet cs M.\\ changeSet csP
     prefixes = reflect (Proxy @ps)
     cGetter (CompositeChgAccum caP caS) reqIds =
         -- We throw error as responses for sets of keys with divergent
         -- prefixes are not expected to ever overlap
-        M.unionWith (error "constructCompositeActions: responses overlap")
+        M.unionWith (error "constructCompositeDaa: responses overlap")
           <$> daaGetter dbaP caP reqIdsP
           <*> daaGetter dbaS caS reqIdsS
       where
         reqIdsP = filterSetByPrefixPred (`S.member` prefixes) reqIds
         reqIdsS = reqIds S.\\ reqIdsP
+
+constructCompositeDaaM
+    :: forall ps chgAccumPrimary chgAccumSecondary id value m .
+    (Reifies ps (Set Prefix), Ord id, Monad m, IdSumPrefixed id)
+    => DbAccessActionsM chgAccumPrimary id value m
+    -> DbAccessActionsM chgAccumSecondary id value m
+    -> DbAccessActionsM (CompositeChgAccum chgAccumPrimary chgAccumSecondary ps) id value m
+constructCompositeDaaM dbaP dbaS = DbAccessActionsM daa' modifyAccum
+  where
+    daa' = constructCompositeDaa (daaAccess dbaP) (daaAccess dbaS)
+    prefixes = reflect (Proxy @ps)
+    modifyAccum (CompositeChgAccum cP cS) (OldestFirst css) =
+        liftA2 glue <$> daaModifyAccum dbaP cP cssP <*> daaModifyAccum dbaS cS cssS
+      where
+        (cssP, cssS) = bimap OldestFirst OldestFirst $ unzip $ splitCS prefixes <$> css
+        glue (OldestFirst accsP) (OldestFirst accsS) =
+            OldestFirst $ uncurry CompositeChgAccum <$> zip accsP accsS
+
+splitCS
+    :: forall id value . (Ord id, IdSumPrefixed id)
+    => Set Prefix
+    -> ChangeSet id value
+    -> (ChangeSet id value, ChangeSet id value)
+splitCS prefixes cs = (csP, csS)
+  where
+    csP = filterByPrefixPred @id (`S.member` prefixes) cs
+    csS = ChangeSet $ changeSet cs M.\\ changeSet csP
+
+constructCompositeDaaU
+  :: forall ps chgAccumPrimary chgAccumSecondary undoPrimary undoSecondary id value m .
+    (Reifies ps (Set Prefix), Ord id, Monad m, IdSumPrefixed id)
+    => DbAccessActionsU chgAccumPrimary undoPrimary id value m
+    -> DbAccessActionsU chgAccumSecondary undoSecondary id value m
+    -> DbAccessActionsU (CompositeChgAccum chgAccumPrimary chgAccumSecondary ps)
+                        (CompositeUndo undoPrimary undoSecondary ps) id value m
+constructCompositeDaaU dbaP dbaS = DbAccessActionsU daaM' modifyAccumU computeUndo
+  where
+    daaM' = constructCompositeDaaM (daaAccessM dbaP) (daaAccessM dbaS)
+
+    modifyAccumU
+      :: CompositeChgAccum chgAccumPrimary chgAccumSecondary ps
+      -> NewestFirst [] (CompositeUndo undoPrimary undoSecondary ps)
+      -> m (Either (CSMappendException id) (CompositeChgAccum chgAccumPrimary chgAccumSecondary ps))
+    modifyAccumU (CompositeChgAccum cP cS) (NewestFirst us) =
+        liftA2 CompositeChgAccum <$> daaModifyAccumUndo dbaP cP usP <*> daaModifyAccumUndo dbaS cS usS
+      where
+        (usP, usS) = bimap NewestFirst NewestFirst $ unzip $ splitUndo <$> us
+
+    splitUndo (CompositeUndo undoP undoS) = (undoP, undoS)
+
+    computeUndo
+      :: CompositeChgAccum chgAccumPrimary chgAccumSecondary ps
+      -> CompositeChgAccum chgAccumPrimary chgAccumSecondary ps
+      -> m (Either (CSMappendException id) (CompositeUndo undoPrimary undoSecondary ps))
+    computeUndo (CompositeChgAccum cP cS) (CompositeChgAccum cP' cS') =
+        liftA2 CompositeUndo <$> daaComputeUndo dbaP cP cP' <*> daaComputeUndo dbaS cS cS'

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/Simple.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/Simple.hs
@@ -3,7 +3,9 @@
 
 module Snowdrop.Execution.DbActions.Simple
        (
-         sumChangeSetDBA
+         sumChangeSetDaa
+       , sumChangeSetDaaM
+       , sumChangeSetDaaU
        , SumChangeSet (..)
        , mappendStOrThrow
        , accumToDiff
@@ -13,15 +15,13 @@ module Snowdrop.Execution.DbActions.Simple
 import           Universum
 
 import           Control.Monad.Except (throwError)
-import qualified Data.ByteString as BS
 import           Data.Default (Default (def))
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 
-import           Snowdrop.Core (CSMappendException (..), ChangeSet (..), ChgAccumModifier (..),
-                                IdSumPrefixed (..), Prefix (..), StateP, StateR, Undo (..),
-                                ValueOp (..), changeSetToMap, csNew, filterByPrefix,
-                                mappendChangeSet)
+import           Snowdrop.Core (CSMappendException (..), ChangeSet (..), IdSumPrefixed (..),
+                                Prefix (..), StateP, StateR, ValueOp (..), changeSetToMap, csNew,
+                                diffChangeSet, filterByPrefix, mappendChangeSet)
 import           Snowdrop.Util
 
 import           Snowdrop.Execution.DbActions.Types
@@ -68,33 +68,52 @@ queryAccumOne (SumChangeSet (ChangeSet csm)) = flip M.lookup csm
 getNewKeys :: IdSumPrefixed id => SumChangeSet id value -> Prefix -> Map id value
 getNewKeys (SumChangeSet cs) p = csNew $ filterByPrefix p cs
 
-sumChangeSetDBA
+sumChangeSetDaaM
     :: forall id value m . (IdSumPrefixed id, Ord id, MonadCatch m)
-    => (StateR id -> m (StateP id value))
-    -> (forall b. Prefix -> b -> ((id, value) -> b -> b) -> m b)
-    -> DbAccessActions (SumChangeSet id value) id value m
-sumChangeSetDBA getImpl iterImpl =
-    DbAccessActions
-      getter
-      modifySumChgSetA
-      (chgAccumIter iterImpl)
+    => DbAccessActions (SumChangeSet id value) id value m
+    -> DbAccessActionsM (SumChangeSet id value) id value m
+sumChangeSetDaaM daa = daaM
   where
-    getter = chgAccumGetter getImpl
+    liftA' f a b = pure $ f a b
+    daaM = DbAccessActionsM daa (liftA' modifyAccum)
 
-    modifySumChgSetA accum = \case
-        CAMChange cs -> processCS cs
-        CAMRevert (Undo cs _sn) -> processCS cs
+    modifyAccum
+      :: SumChangeSet id value
+      -> OldestFirst [] (ChangeSet id value)
+      -> Either (CSMappendException id) (OldestFirst [] (SumChangeSet id value))
+    modifyAccum initScs (OldestFirst css) = OldestFirst <$> scss
       where
-        processCS cs' =
-          (liftA2 (,) $ accum `modifySumChgSet` cs')
-            <$> runExceptT (flip Undo BS.empty <$> computeUndo accum cs')
+        scss = reverse . snd <$> foldM modScs (initScs, []) css
+        modScs (scs, res) cs = (\scs' -> (scs', scs':res)) <$> scs `modifySumChgSet` cs
+
+sumChangeSetDaaU
+    :: forall id value m . (IdSumPrefixed id, Ord id, MonadCatch m)
+    => DbAccessActions (SumChangeSet id value) id value m
+    -> DbAccessActionsU (SumChangeSet id value) (ChangeSet id value) id value m
+sumChangeSetDaaU daa = daaU
+  where
+    liftA' f a b = pure $ f a b
+    daaU = DbAccessActionsU (sumChangeSetDaaM daa) (liftA' modifyAccumU) computeUndo
+
+    modifyAccumU
+      :: SumChangeSet id value
+      -> NewestFirst [] (ChangeSet id value)
+      -> Either (CSMappendException id) (SumChangeSet id value)
+    modifyAccumU scs (NewestFirst css) = foldM modifySumChgSet scs css
 
     computeUndo
         :: SumChangeSet id value
+        -> SumChangeSet id value
+        -> m (Either (CSMappendException id) (ChangeSet id value))
+    computeUndo scs@(SumChangeSet scs1) (SumChangeSet scs2) =
+        either (pure . Left) (computeUndoDo scs) (scs2 `diffChangeSet` scs1)
+
+    computeUndoDo
+        :: SumChangeSet id value
         -> ChangeSet id value
-        -> ExceptT (CSMappendException id) m (ChangeSet id value)
-    computeUndo ca (ChangeSet cs) = do
-        vals <- lift $ getter ca (M.keysSet cs)
+        -> m (Either (CSMappendException id) (ChangeSet id value))
+    computeUndoDo ca (ChangeSet cs) = runExceptT $ do
+        vals <- lift $ (daaGetter daa) ca (M.keysSet cs)
         let processOne m (k, valueop) = case (valueop, k `M.lookup` vals) of
               (New _, Nothing)      -> pure $ M.insert k Rem m
               (Upd _, Just v0)      -> pure $ M.insert k (Upd v0) m
@@ -102,6 +121,14 @@ sumChangeSetDBA getImpl iterImpl =
               (Rem, Just v0)        -> pure $ M.insert k (New v0) m
               _                     -> throwError (CSMappendException k)
         ChangeSet <$> foldM processOne mempty (M.toList cs)
+
+sumChangeSetDaa
+    :: (IdSumPrefixed id, Ord id, Applicative m)
+    => (StateR id -> m (StateP id value))
+    -> (forall b . Prefix -> b -> ((id, value) -> b -> b) -> m b)
+    -> DbAccessActions (SumChangeSet id value) id value m
+sumChangeSetDaa getterImpl iterImpl =
+    DbAccessActions (chgAccumGetter getterImpl) (chgAccumIter iterImpl)
 
 chgAccumIter
     :: (IdSumPrefixed id, Ord id, Applicative m)
@@ -120,7 +147,6 @@ chgAccumIter iter accum prefix initB foldF =
             Just (Upd newV) -> foldF (i, newV) b
             Just (New _)    -> b -- something strange happened
      in iter prefix newKeysB newFoldF
-
 
 chgAccumGetter
     :: (IdSumPrefixed id, Ord id, Applicative m)

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/Types.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/Types.hs
@@ -4,10 +4,13 @@
 module Snowdrop.Execution.DbActions.Types
        (
          DbAccessActions (..)
+       , DbAccessActionsM (..)
+       , DbAccessActionsU (..)
        , DbModifyActions (..)
        , DbActionsException (..)
        , RememberForProof (..)
        , ClientMode (..)
+       , DbActions (..)
        ) where
 
 import           Universum
@@ -15,24 +18,68 @@ import           Universum
 import qualified Data.Text.Buildable
 import           Formatting (bprint, build, (%))
 
-import           Snowdrop.Core (CSMappendException (..), ChgAccumModifier, Prefix (..), StateP,
-                                StateR, Undo)
+import           Snowdrop.Core (CSMappendException (..), ChangeSet, DbAccess (..), DbAccessM (..),
+                                DbAccessU (..), FoldF (..), Prefix (..), StateP, StateR)
+import           Snowdrop.Util (NewestFirst, OldestFirst)
 
 data DbAccessActions chgAccum id value m = DbAccessActions
-    { daaGetter      :: chgAccum -> StateR id -> m (StateP id value)
+    { daaGetter :: chgAccum -> StateR id -> m (StateP id value)
       -- ^ Retrieves values corresponding to specified keys (doesn't modify the state)
-    , daaModifyAccum :: chgAccum
-                     -> ChgAccumModifier id value
-                     -> m (Either (CSMappendException id) (chgAccum, Undo id value))
-      -- ^ Modify change accumulater with specified change set (doesn't modify the state)
-    , daaIter        :: forall b . chgAccum -> Prefix -> b -> ((id, value) -> b -> b) -> m b
+    , daaIter   :: forall b . chgAccum -> Prefix -> b -> ((id, value) -> b -> b) -> m b
       -- ^ Iterate through keys with specified prefix (doesn't modify the state)
     }
 
+data DbAccessActionsM chgAccum id value m = DbAccessActionsM
+    { daaAccess      :: DbAccessActions chgAccum id value m
+      -- ^ Retrieves values corresponding to specified keys (doesn't modify the state)
+    , daaModifyAccum :: chgAccum
+                     -> OldestFirst [] (ChangeSet id value)
+                     -> m (Either (CSMappendException id) (OldestFirst [] chgAccum))
+      -- ^ Modify change accumulator with specified change set (doesn't modify the state)
+    }
+
+data DbAccessActionsU chgAccum undo id value m = DbAccessActionsU
+    { daaAccessM          :: DbAccessActionsM chgAccum id value m
+      -- ^ Retrieves values corresponding to specified keys (doesn't modify the state)
+    , daaModifyAccumUndo  :: chgAccum
+                          -> NewestFirst [] undo
+                          -> m (Either (CSMappendException id) chgAccum)
+    , daaComputeUndo      :: chgAccum
+                             -- ^ base change accumulator
+                          -> chgAccum
+                             -- ^ modified change accumulator
+                          -> m (Either (CSMappendException id) undo)
+                             -- ^ undo object, such that @modified `applyUndo` undo = base@
+    }
+
+class DbActions effect actions param m where
+    executeEffect :: effect r -> actions m -> param -> m r
+
+instance Functor m => DbActions (DbAccess id value)
+                                (DbAccessActions chgAccum id value) chgAccum m where
+    executeEffect (DbQuery req cont) daa chgAccum =
+        cont <$> daaGetter daa chgAccum req
+    executeEffect (DbIterator prefix (FoldF (e, acc, cont))) daa chgAccum =
+        cont <$> daaIter daa chgAccum prefix e acc
+
+instance Functor m => DbActions (DbAccessU chgAccum undo id value)
+                                (DbAccessActionsU chgAccum undo id value) chgAccum m where
+    executeEffect (DbAccessM daM) (daaAccessM -> daaM) chgAccum = executeEffect daM daaM chgAccum
+    executeEffect (DbComputeUndo cs cont) daaU chgAccum =
+        cont <$> daaComputeUndo daaU chgAccum cs
+    executeEffect (DbModifyAccumUndo undos cont) daaU chgAccum =
+        cont <$> daaModifyAccumUndo daaU chgAccum undos
+
+instance Functor m => DbActions (DbAccessM chgAccum id value)
+                                (DbAccessActionsM chgAccum id value) chgAccum m where
+    executeEffect (DbAccess da) (daaAccess -> daa) chgAccum = executeEffect da daa chgAccum
+    executeEffect (DbModifyAccum chgSet cont) daaM chgAccum =
+        cont <$> daaModifyAccum daaM chgAccum chgSet
+
 -- | Db modify access actions model following use of
-data DbModifyActions chgAccum id value m proof = DbModifyActions
-    { dmaAccessActions :: DbAccessActions chgAccum id value m
-    , dmaApply         :: chgAccum -> m proof
+data DbModifyActions chgAccum undo id value m proof = DbModifyActions
+    { dmaAccess :: DbAccessActionsU chgAccum undo id value m
+    , dmaApply  :: chgAccum -> m proof
     }
 
 data DbActionsException

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/Types.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/Types.hs
@@ -22,7 +22,7 @@ import           Snowdrop.Core (CSMappendException (..), ChangeSet, DbAccess (..
                                 DbAccessU (..), FoldF (..), Prefix (..), StateP, StateR)
 import           Snowdrop.Util (NewestFirst, OldestFirst)
 
--- | Actions to execute $DbAccess effect.
+-- | Actions to execute 'DbAccess' effect.
 -- Methods provided in the data type are not intended to modify any internal state.
 data DbAccessActions chgAccum id value m = DbAccessActions
     { daaGetter :: chgAccum -> StateR id -> m (StateP id value)
@@ -31,11 +31,11 @@ data DbAccessActions chgAccum id value m = DbAccessActions
     -- ^ Iterate through keys with specified prefix (doesn't modify the state)
     }
 
--- | Actions to execute $DbAccessM effect.
+-- | Actions to execute 'DbAccessM' effect.
 -- Methods provided in the data type are not intended to modify any internal state.
 data DbAccessActionsM chgAccum id value m = DbAccessActionsM
     { daaAccess      :: DbAccessActions chgAccum id value m
-    -- ^ Actions to execute $DbAccess effect.
+    -- ^ Actions to execute 'DbAccess' effect.
     , daaModifyAccum :: chgAccum
                      -> OldestFirst [] (ChangeSet id value)
                      -> m (Either (CSMappendException id) (OldestFirst [] chgAccum))
@@ -46,11 +46,11 @@ data DbAccessActionsM chgAccum id value m = DbAccessActionsM
     -- returns modified accumulator.
     }
 
--- | Actions to execute $DbAccessU effect.
+-- | Actions to execute 'DbAccessU' effect.
 -- Methods provided in the data type are not intended to modify any internal state.
 data DbAccessActionsU chgAccum undo id value m = DbAccessActionsU
     { daaAccessM          :: DbAccessActionsM chgAccum id value m
-    -- ^ Actions to execute $DbAccessM effect.
+    -- ^ Actions to execute 'DbAccessM' effect.
     , daaModifyAccumUndo  :: chgAccum
                           -> NewestFirst [] undo
                           -> m (Either (CSMappendException id) chgAccum)
@@ -96,7 +96,7 @@ instance Functor m => DbActions (DbAccessM chgAccum id value)
 -- | Actions to access and modify state.
 data DbModifyActions chgAccum undo id value m proof = DbModifyActions
     { dmaAccess :: DbAccessActionsU chgAccum undo id value m
-    -- ^ Actions to execute $DbAccessU effect.
+    -- ^ Actions to execute 'DbAccessU' effect.
     , dmaApply  :: chgAccum -> m proof
     -- ^ Apply provided change accumulator to internal state
     -- and return proof of the internal state change.

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/Types.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/Types.hs
@@ -22,37 +22,54 @@ import           Snowdrop.Core (CSMappendException (..), ChangeSet, DbAccess (..
                                 DbAccessU (..), FoldF (..), Prefix (..), StateP, StateR)
 import           Snowdrop.Util (NewestFirst, OldestFirst)
 
+-- | Actions to execute $DbAccess effect.
+-- Methods provided in the data type are not intended to modify any internal state.
 data DbAccessActions chgAccum id value m = DbAccessActions
     { daaGetter :: chgAccum -> StateR id -> m (StateP id value)
-      -- ^ Retrieves values corresponding to specified keys (doesn't modify the state)
+    -- ^ Retrieves values corresponding to specified keys (doesn't modify the state)
     , daaIter   :: forall b . chgAccum -> Prefix -> b -> ((id, value) -> b -> b) -> m b
-      -- ^ Iterate through keys with specified prefix (doesn't modify the state)
+    -- ^ Iterate through keys with specified prefix (doesn't modify the state)
     }
 
+-- | Actions to execute $DbAccessM effect.
+-- Methods provided in the data type are not intended to modify any internal state.
 data DbAccessActionsM chgAccum id value m = DbAccessActionsM
     { daaAccess      :: DbAccessActions chgAccum id value m
-      -- ^ Retrieves values corresponding to specified keys (doesn't modify the state)
+    -- ^ Actions to execute $DbAccess effect.
     , daaModifyAccum :: chgAccum
                      -> OldestFirst [] (ChangeSet id value)
                      -> m (Either (CSMappendException id) (OldestFirst [] chgAccum))
-      -- ^ Modify change accumulator with specified change set (doesn't modify the state)
+    -- ^ Modify change accumulator with specified list of change sets.
+    -- First argument is a change accumulator to modify.
+    -- Second argument is a list of change sets (in oldest first order).
+    -- Function applies each change set to accumulator in oldest first order,
+    -- returns modified accumulator.
     }
 
+-- | Actions to execute $DbAccessU effect.
+-- Methods provided in the data type are not intended to modify any internal state.
 data DbAccessActionsU chgAccum undo id value m = DbAccessActionsU
     { daaAccessM          :: DbAccessActionsM chgAccum id value m
-      -- ^ Retrieves values corresponding to specified keys (doesn't modify the state)
+    -- ^ Actions to execute $DbAccessM effect.
     , daaModifyAccumUndo  :: chgAccum
                           -> NewestFirst [] undo
                           -> m (Either (CSMappendException id) chgAccum)
+    -- ^ Applies undos to a given accumulator.
+    -- First argument is a change accumulator to modify.
+    -- Second argument is a list of undo object (in newest first order).
+    -- Function applies each undo to accumulator in newest first order,
+    -- returns modified accumulator.
     , daaComputeUndo      :: chgAccum
-                             -- ^ base change accumulator
                           -> chgAccum
-                             -- ^ modified change accumulator
                           -> m (Either (CSMappendException id) undo)
-                             -- ^ undo object, such that @modified `applyUndo` undo = base@
+    -- ^ Computes undo. First argument is a base change accumulator.
+    -- Second argument is a modified change accumulator.
+    -- Function returns an undo object, such that @modified `applyUndo` undo = base@
     }
 
+-- | Class provided to execute effect with ations corresponding to it.
 class DbActions effect actions param m where
+    -- | Execute @effect r@ using @actions m@ and return value @r@ in monad @m@.
     executeEffect :: effect r -> actions m -> param -> m r
 
 instance Functor m => DbActions (DbAccess id value)
@@ -76,10 +93,16 @@ instance Functor m => DbActions (DbAccessM chgAccum id value)
     executeEffect (DbModifyAccum chgSet cont) daaM chgAccum =
         cont <$> daaModifyAccum daaM chgAccum chgSet
 
--- | Db modify access actions model following use of
+-- | Actions to access and modify state.
 data DbModifyActions chgAccum undo id value m proof = DbModifyActions
     { dmaAccess :: DbAccessActionsU chgAccum undo id value m
+    -- ^ Actions to execute $DbAccessU effect.
     , dmaApply  :: chgAccum -> m proof
+    -- ^ Apply provided change accumulator to internal state
+    -- and return proof of the internal state change.
+    -- This proof is further to be used on light client
+    -- in order to validate change without full state access
+    -- (in case actions provide this functionality).
     }
 
 data DbActionsException

--- a/snowdrop-execution/src/Snowdrop/Execution/IOExecutor.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/IOExecutor.hs
@@ -29,10 +29,10 @@ import           Loot.Base.HasLens (HasLens', lensOf)
 import qualified Loot.Base.HasLens as Loot
 import qualified Loot.Log.Rio as Rio
 
-import           Snowdrop.Core (BaseM (..), ChgAccum, ChgAccumCtx (..),
-                                DbAccess (..), ERoComp, ERwComp, Effectful (..), FoldF (..),
-                                StatePException, getCAOrDefault, runERwComp, CtxConcurrently (..))
-import           Snowdrop.Execution.DbActions (DbAccessActions (..))
+import           Snowdrop.Core (BaseM (..), ChgAccum, ChgAccumCtx (..), CtxConcurrently (..),
+                                DbAccessM, DbAccessU, ERwComp, Effectful (..), StatePException,
+                                getCAOrDefault, runERwComp)
+import           Snowdrop.Execution.DbActions (DbActions (..))
 import           Snowdrop.Execution.Restrict (RestrictCtx)
 import           Snowdrop.Util (ExecM, HasException, HasGetter (gett), HasLens (sett))
 import qualified Snowdrop.Util as Log
@@ -99,63 +99,65 @@ runBaseMIO
     -> ExecM a
 runBaseMIO bm ctx = runReaderT (unBaseMIO @e @eff $ unBaseM bm) ctx
 
-data IOCtx chgAccum id value = IOCtx
-    { _ctxChgAccum   :: ChgAccumCtx (IOCtx chgAccum id value)
+data IOCtx daa = IOCtx
+    { _ctxChgAccum   :: ChgAccumCtx (IOCtx daa)
     , _ctxRestrict   :: RestrictCtx
-    , _ctxExec       :: BaseMIOExec (DbAccess chgAccum id value) (IOCtx chgAccum id value)
+    , _ctxExec       :: BaseMIOExec daa (IOCtx daa)
     , _ctxLogger     :: Log.LoggingIO
     , _ctxConcurrent :: CtxConcurrently
     }
 
 makeLenses ''IOCtx
 
-type instance ChgAccum (IOCtx chgAccum id value) = chgAccum
+type instance ChgAccum (IOCtx (DbAccessU chgAccum undo id value)) = chgAccum
+type instance ChgAccum (IOCtx (DbAccessM chgAccum id value)) = chgAccum
 
-instance Loot.HasLens Log.LoggingIO (IOCtx chgAccum id value) Log.LoggingIO where
+instance Loot.HasLens Log.LoggingIO (IOCtx daa) Log.LoggingIO where
     lensOf = ctxLogger
 
-instance HasLens (IOCtx chgAccum id value) RestrictCtx where
+instance HasLens (IOCtx daa) RestrictCtx where
     sett ctx val = ctx { _ctxRestrict = val }
 
-instance HasGetter (IOCtx chgAccum id value) RestrictCtx where
+instance HasGetter (IOCtx daa) RestrictCtx where
     gett = _ctxRestrict
 
 instance HasLens
-           (IOCtx chgAccum id value)
-           (BaseMIOExec (DbAccess chgAccum id value) (IOCtx chgAccum id value)) where
+           (IOCtx daa)
+           (BaseMIOExec daa (IOCtx daa)) where
     sett ctx val = ctx { _ctxExec = val }
 
 instance HasGetter
-           (IOCtx chgAccum id value)
-           (BaseMIOExec (DbAccess chgAccum id value) (IOCtx chgAccum id value)) where
+           (IOCtx daa)
+           (BaseMIOExec daa (IOCtx daa)) where
     gett = _ctxExec
 
-instance HasLens (IOCtx chgAccum id value) (ChgAccumCtx (IOCtx chgAccum id value)) where
+instance HasLens (IOCtx daa) (ChgAccumCtx (IOCtx daa)) where
     sett ctx val = ctx { _ctxChgAccum = val }
 
-instance HasGetter (IOCtx chgAccum id value) (ChgAccumCtx (IOCtx chgAccum id value)) where
+instance HasGetter (IOCtx daa) (ChgAccumCtx (IOCtx daa)) where
     gett = _ctxChgAccum
 
-instance HasLens (IOCtx chgAccum id value) CtxConcurrently where
+instance HasLens (IOCtx daa) CtxConcurrently where
     sett ctx val = ctx { _ctxConcurrent = val }
 
-instance HasGetter (IOCtx chgAccum id value) CtxConcurrently where
+instance HasGetter (IOCtx daa) CtxConcurrently where
     gett = _ctxConcurrent
 
 runERoCompIO
-    :: forall e id value chgAccum a ctx m.
+  :: forall e da daa a ctx m.
     ( Show e
     , Typeable e
-    , Default chgAccum
+    , Default (ChgAccum (IOCtx da))
     , MonadIO m
     , MonadReader ctx m
     , HasLens' ctx Log.LoggingIO
+    , DbActions da daa (ChgAccum (IOCtx da)) ExecM
     )
-    => DbAccessActions chgAccum id value ExecM
-    -> Maybe chgAccum
-    -> ERoComp e id value (IOCtx chgAccum id value) a
+    => daa ExecM
+    -> Maybe (ChgAccum (IOCtx da))
+    -> BaseM e da (IOCtx da) a
     -> m a
-runERoCompIO dba initAcc comp = do
+runERoCompIO daa initAcc comp = do
     logger <- view (lensOf @Log.LoggingIO)
     liftIO $ Log.runRIO logger $ runBaseMIO comp $
         IOCtx
@@ -166,26 +168,23 @@ runERoCompIO dba initAcc comp = do
           , _ctxConcurrent = def
           }
   where
-    exec = BaseMIOExec $ \(getCAOrDefault . _ctxChgAccum -> chgAccum) dAccess ->
-        case dAccess of
-            DbQuery req cont                         -> cont <$> daaGetter dba chgAccum req
-            DbIterator prefix (FoldF (e, acc, cont)) -> cont <$> daaIter dba chgAccum prefix e acc
-            DbModifyAccum accum chgSet cont          -> cont <$> daaModifyAccum dba accum chgSet
+    exec = BaseMIOExec $ \(getCAOrDefault . _ctxChgAccum -> chgAccum) da -> executeEffect da daa chgAccum
 
 runERwCompIO
     :: ( Show e
        , Typeable e
-       , Default chgAccum
+       , Default (ChgAccum (IOCtx da))
        , HasException e StatePException
        , MonadIO m
        , MonadReader ctx m
        , HasLens' ctx Log.LoggingIO
+       , DbActions da daa (ChgAccum (IOCtx da)) ExecM
        )
-    => DbAccessActions chgAccum id value ExecM
+    => daa ExecM
     -> s
-    -> ERwComp e id value (IOCtx chgAccum id value) s a
+    -> ERwComp e da (IOCtx da) s a
     -> m (a, s)
-runERwCompIO dba initS comp = do
+runERwCompIO daa initS comp = do
     logger <- view (lensOf @Log.LoggingIO)
     liftIO $ Log.runRIO logger $ runBaseMIO (runERwComp comp initS) $
         IOCtx
@@ -196,8 +195,4 @@ runERwCompIO dba initS comp = do
           , _ctxConcurrent = def
           }
   where
-    exec = BaseMIOExec $ \(getCAOrDefault . _ctxChgAccum -> chgAccum) dAccess ->
-        case dAccess of
-            DbQuery req cont                         -> cont <$> daaGetter dba chgAccum req
-            DbIterator prefix (FoldF (e, acc, cont)) -> cont <$> daaIter dba chgAccum prefix e acc
-            DbModifyAccum accum chgSet cont          -> cont <$> daaModifyAccum dba accum chgSet
+    exec = BaseMIOExec $ \(getCAOrDefault . _ctxChgAccum -> chgAccum) dAccess -> executeEffect dAccess daa chgAccum

--- a/snowdrop-execution/src/Snowdrop/Execution/IOExecutor.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/IOExecutor.hs
@@ -171,15 +171,16 @@ runERoCompIO daa initAcc comp = do
     exec = BaseMIOExec $ \(getCAOrDefault . _ctxChgAccum -> chgAccum) da -> executeEffect da daa chgAccum
 
 runERwCompIO
-    :: ( Show e
-       , Typeable e
-       , Default (ChgAccum (IOCtx da))
-       , HasException e StatePException
-       , MonadIO m
-       , MonadReader ctx m
-       , HasLens' ctx Log.LoggingIO
-       , DbActions da daa (ChgAccum (IOCtx da)) ExecM
-       )
+  :: forall e da daa s ctx m a .
+    ( Show e
+    , Typeable e
+    , Default (ChgAccum (IOCtx da))
+    , HasException e StatePException
+    , MonadIO m
+    , MonadReader ctx m
+    , HasLens' ctx Log.LoggingIO
+    , DbActions da daa (ChgAccum (IOCtx da)) ExecM
+    )
     => daa ExecM
     -> s
     -> ERwComp e da (IOCtx da) s a

--- a/snowdrop-execution/src/Snowdrop/Execution/Mempool/Core.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/Mempool/Core.hs
@@ -18,11 +18,11 @@ import           Universum
 import           Control.Lens (lens)
 import           Data.Default (Default (..))
 
-import           Snowdrop.Core (CSMappendException (..), ChgAccum, ChgAccumCtx,
-                                ChgAccumModifier (..), ERoComp, ERwComp, SomeTx, StatePException,
-                                StateTx (..), Undo, Validator, applySomeTx, liftERoComp,
-                                modifyRwCompChgAccum, runValidator)
-import           Snowdrop.Execution.DbActions (DbAccessActions)
+import           Snowdrop.Core (CSMappendException (..), ChgAccum, ChgAccumCtx, DbAccessM, ERoCompM,
+                                ERwComp, SomeTx, StatePException, StateTx (..), Validator,
+                                applySomeTx, convertEffect, liftERoComp, modifyAccumOne,
+                                runValidator)
+import           Snowdrop.Execution.DbActions (DbAccessActionsM)
 import           Snowdrop.Execution.IOExecutor (IOCtx, runERwCompIO)
 import           Snowdrop.Util
 
@@ -32,13 +32,13 @@ import           Snowdrop.Util
 
 
 type ExpanderRawTx e id c value ctx rawtx =
-    rawtx -> ERoComp e id value ctx (SomeTx id value c)
+    rawtx -> ERoCompM e id value ctx (SomeTx id value c)
 
 type RwActionWithMempool e id value rawtx ctx a =
-    ERwComp e id value ctx (MempoolState id value (ChgAccum ctx) rawtx) a
+    ERwComp e (DbAccessM (ChgAccum ctx) id value) ctx (MempoolState id value (ChgAccum ctx) rawtx) a
 
 type ProcessStateTx e id c value rawtx ctx =
-    SomeTx id value c -> RwActionWithMempool e id value rawtx ctx (Undo id value)
+    SomeTx id value c -> RwActionWithMempool e id value rawtx ctx ()
 
 data MempoolConfig e id c value ctx rawtx = MempoolConfig
     { mcExpandTx  :: ExpanderRawTx e id c value ctx rawtx
@@ -46,7 +46,7 @@ data MempoolConfig e id c value ctx rawtx = MempoolConfig
     }
 
 data MempoolState id value chgAccum rawtx = MempoolState
-    { msTxs      :: [(rawtx, Undo id value)]
+    { msTxs      :: [rawtx]
     , msChgAccum :: chgAccum
     }
 
@@ -61,7 +61,7 @@ instance HasGetter (MempoolState id value chgAccum rawtx) chgAccum where
 instance HasLens (MempoolState id value chgAccum rawtx) chgAccum where
     sett s x = s {msChgAccum = x}
 
-msTxsL :: Lens' (MempoolState id value chgAccum rawtx) [(rawtx, Undo id value)]
+msTxsL :: Lens' (MempoolState id value chgAccum rawtx) [rawtx]
 msTxsL = lens msTxs (\s x -> s {msTxs = x})
 
 instance Default chgAccum => Default (MempoolState id value chgAccum rawtx) where
@@ -87,18 +87,21 @@ defaultMempoolConfig
     -> MempoolConfig e id (RContains txtypes) value ctx rawtx
 defaultMempoolConfig expander validator = MempoolConfig {
       mcProcessTx = applySomeTx $ \tx -> do
-        liftERoComp $ runValidator validator tx
-        modifyRwCompChgAccum (CAMChange $ txBody tx)
+        chgAccum' <- liftERoComp $ do
+            () <- convertEffect $ runValidator validator tx
+            modifyAccumOne (txBody tx)
+        modify (flip sett chgAccum')
     , mcExpandTx = expander
     }
 
 actionWithMempool
     :: ( Show e, Typeable e, Default chgAccum
        , HasReview e StatePException
+       , chgAccum ~ ChgAccum (IOCtx (DbAccessM chgAccum id value))
        )
     => Mempool id value chgAccum rawtx
-    -> DbAccessActions chgAccum id value ExecM
-    -> RwActionWithMempool e id value rawtx (IOCtx chgAccum id value) a
+    -> DbAccessActionsM chgAccum id value ExecM
+    -> RwActionWithMempool e id value rawtx (IOCtx (DbAccessM chgAccum id value)) a
     -> ExecM a
 actionWithMempool mem@Mempool{..} dbActs callback = do
     Versioned{vsVersion=version,..} <- liftIO $ atomically $ readTVar mempoolState
@@ -119,5 +122,5 @@ createMempool = Mempool <$> atomically (newTVar def)
 getMempoolTxs
     :: (Default chgAccum, MonadIO m)
     => Mempool id value chgAccum rawtx
-    -> m [(rawtx, Undo id value)]
+    -> m [rawtx]
 getMempoolTxs Mempool{..} = msTxs . vsData <$> atomically (readTVar mempoolState)

--- a/snowdrop-execution/src/Snowdrop/Execution/Mempool/Logic.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/Mempool/Logic.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE Rank2Types          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Snowdrop.Execution.Mempool.Logic
        ( evictMempool
        , processTxAndInsertToMempool

--- a/snowdrop-execution/src/Snowdrop/Execution/Mempool/Logic.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/Mempool/Logic.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE DataKinds  #-}
-{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE Rank2Types          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Snowdrop.Execution.Mempool.Logic
        ( evictMempool
        , processTxAndInsertToMempool
-       , createBlockDbModifyAction
        , normalizeMempool
        , Rejected (..)
        ) where
@@ -15,12 +15,9 @@ import           Control.Lens ((%=))
 import           Control.Monad.Except (catchError)
 import           Data.Default (Default (..))
 
-import           Snowdrop.Core (CSMappendException (..), ChgAccum, ChgAccumCtx, IdSumPrefixed (..),
-                                StatePException, Undo, liftERoComp)
-import           Snowdrop.Execution.DbActions (DbModifyActions (..))
-import           Snowdrop.Execution.IOExecutor (IOCtx)
-import           Snowdrop.Execution.Mempool.Core (Mempool, MempoolConfig (..), MempoolState (..),
-                                                  RwActionWithMempool, actionWithMempool, msTxsL)
+import           Snowdrop.Core (ChgAccum, ChgAccumCtx, StatePException, liftERoComp)
+import           Snowdrop.Execution.Mempool.Core (MempoolConfig (..), MempoolState (..),
+                                                  RwActionWithMempool, msTxsL)
 import           Snowdrop.Util
 
 ---------------------------
@@ -29,7 +26,7 @@ import           Snowdrop.Util
 
 evictMempool
     :: Default (ChgAccum ctx)
-    => RwActionWithMempool e id value rawtx ctx [(rawtx, Undo id value)]
+    => RwActionWithMempool e id value rawtx ctx [rawtx]
 evictMempool = gets msTxs <* put def
 
 processTxAndInsertToMempool
@@ -41,8 +38,8 @@ processTxAndInsertToMempool
     -> RwActionWithMempool e id value rawtx ctx ()
 processTxAndInsertToMempool MempoolConfig{..} rawtx = do
     tx <- liftERoComp (mcExpandTx rawtx)
-    undo <- mcProcessTx tx
-    msTxsL %= (++ [(rawtx, undo)])
+    () <- mcProcessTx tx
+    msTxsL %= (++ [rawtx])
 
 newtype Rejected rawtx = Rejected { getRejected :: [rawtx] }
 
@@ -54,32 +51,15 @@ normalizeMempool
     => MempoolConfig e id txtype value ctx rawtx
     -> RwActionWithMempool e id value rawtx ctx (Rejected rawtx)
 normalizeMempool MempoolConfig{..} = do
-    txs <- map fst <$> evictMempool
+    txs <- evictMempool
     (rejected, _) <- processAll txs
     pure rejected
   where
     processOne rawtx = do
         tx <- liftERoComp (mcExpandTx rawtx)
-        (rawtx,) <$> mcProcessTx tx
+        rawtx <$ mcProcessTx tx
 
     processAll txs = fmap (first Rejected . partitionEithers) $ do
         forM txs $ \rawtx ->
             (Right <$> processOne rawtx)
               `catchError` (\_ -> pure $ Left rawtx)
-
----------------------------------
--- Helpers (work in MonadIO)
----------------------------------
-
-createBlockDbModifyAction
-    :: ( HasExceptions e [CSMappendException id, StatePException], Show e, Typeable e
-       , Default chgAccum
-       , IdSumPrefixed id, Ord id
-       )
-    => MempoolConfig e id txtype value (IOCtx chgAccum id value) rawtx
-    -> Mempool id value chgAccum rawtx
-    -> DbModifyActions chgAccum id value ExecM a
-    -> DbModifyActions chgAccum id value ExecM (a, Rejected rawtx)
-createBlockDbModifyAction cfg mem dbM = DbModifyActions (dmaAccessActions dbM) $ \chg -> do
-    res <- dmaApply dbM chg
-    (res,) <$> actionWithMempool mem (dmaAccessActions dbM) (normalizeMempool cfg)

--- a/snowdrop-execution/src/Snowdrop/Execution/Restrict.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/Restrict.hs
@@ -16,7 +16,7 @@ import qualified Data.Set as S
 import qualified Data.Text.Buildable
 import           Formatting (bprint, build, (%))
 
-import           Snowdrop.Core (ChangeSet (..), ERoComp, IdSumPrefixed (..), Prefix (..))
+import           Snowdrop.Core (BaseM, ChangeSet (..), IdSumPrefixed (..), Prefix (..))
 import           Snowdrop.Util (HasException, HasLens (lensFor), listF, throwLocalError)
 
 data RestrictionInOutException
@@ -39,12 +39,12 @@ instance Default RestrictCtx where
     def = RestrictCtx Nothing
 
 restrictDbAccess
-    :: forall e id value ctx a .
+    :: forall e eff ctx a .
     ( HasLens ctx RestrictCtx
     )
     => Set Prefix
-    -> ERoComp e id value ctx a
-    -> ERoComp e id value ctx a
+    -> BaseM e eff ctx a
+    -> BaseM e eff ctx a
 restrictDbAccess ps = local (lensFor @ctx @RestrictCtx %~ modCtx)
   where
     modCtx (RestrictCtx Nothing)    = RestrictCtx $ Just ps

--- a/snowdrop-util/src/Snowdrop/Util/Containers.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Containers.hs
@@ -18,10 +18,12 @@ import qualified Data.Set as S
 newtype OldestFirst b a = OldestFirst { unOldestFirst :: b a }
 deriving instance Foldable b => Foldable (OldestFirst b)
 deriving instance Functor b => Functor (OldestFirst b)
+deriving instance Applicative b => Applicative (OldestFirst b)
 
 newtype NewestFirst b a = NewestFirst { unNewestFirst :: b a }
 deriving instance Foldable b => Foldable (NewestFirst b)
 deriving instance Functor b => Functor (NewestFirst b)
+deriving instance Applicative b => Applicative (NewestFirst b)
 
 oldestFirstFContainer :: (b a -> c a) -> OldestFirst b a -> OldestFirst c a
 oldestFirstFContainer f (OldestFirst xs) = OldestFirst $ f xs

--- a/snowdrop-util/src/Snowdrop/Util/Containers.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Containers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveTraversable #-}
 module Snowdrop.Util.Containers
        (
          OldestFirst (..)
@@ -19,11 +20,13 @@ newtype OldestFirst b a = OldestFirst { unOldestFirst :: b a }
 deriving instance Foldable b => Foldable (OldestFirst b)
 deriving instance Functor b => Functor (OldestFirst b)
 deriving instance Applicative b => Applicative (OldestFirst b)
+deriving instance Traversable b => Traversable (OldestFirst b)
 
 newtype NewestFirst b a = NewestFirst { unNewestFirst :: b a }
 deriving instance Foldable b => Foldable (NewestFirst b)
 deriving instance Functor b => Functor (NewestFirst b)
 deriving instance Applicative b => Applicative (NewestFirst b)
+deriving instance Traversable b => Traversable (NewestFirst b)
 
 oldestFirstFContainer :: (b a -> c a) -> OldestFirst b a -> OldestFirst c a
 oldestFirstFContainer f (OldestFirst xs) = OldestFirst $ f xs

--- a/snowdrop-util/src/Snowdrop/Util/Helpers.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Helpers.hs
@@ -98,7 +98,7 @@ class (HasPrism s a, Enum s) => IdStorage s a
 getId :: forall ids i . IdStorage ids i => Proxy ids -> i -> Int
 getId _ i = fromEnum (inj i :: ids)
 
--- | Data type, similar to `Either` which provides instances of $Semigroup and $Monoid,
+-- | Data type, similar to `Either` which provides instances of 'Semigroup' and 'Monoid',
 -- well suited for error handling.
 data VerRes e a = VErr e | VRes a
     deriving (Show, Eq)
@@ -112,17 +112,17 @@ instance (Monoid a, Semigroup a) => Monoid (VerRes e a) where
     mempty = VRes mempty
     mappend = (<>)
 
--- | Convert value of type $Either to type $VerRes
+-- | Convert value of type 'Either' to type 'VerRes'
 eitherToVerRes :: Either e a -> VerRes e a
 eitherToVerRes (Right x) = VRes x
 eitherToVerRes (Left e)  = VErr e
 
--- | Convert value of type $VerRes to type $Either
+-- | Convert value of type 'VerRes' to type 'Either'
 verResToEither :: VerRes e a -> Either e a
 verResToEither (VRes x) = Right x
 verResToEither (VErr e) = Left e
 
--- | Helper to run $ExceptT in order to obtain $VerRes
+-- | Helper to run 'ExceptT' in order to obtain 'VerRes'
 runExceptTV :: Monad m => ExceptT e m a -> m (VerRes e a)
 runExceptTV = fmap eitherToVerRes . runExceptT
 

--- a/snowdrop-util/src/Snowdrop/Util/Logging.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Logging.hs
@@ -51,7 +51,7 @@ newtype RIO ctx a = RIO (ReaderT ctx IO a)
 
 deriving instance MonadBase IO (RIO ctx) => MonadBaseControl IO (RIO ctx)
 
--- | Executor for $RIO monad
+-- | Executor for 'RIO' monad
 runRIO :: MonadIO m => ctx -> RIO ctx a -> m a
 runRIO ctx (RIO act) = liftIO $ runReaderT act ctx
 
@@ -93,7 +93,7 @@ defaultLogCfg = LW.productionB & LW.lcTermSeverityOut .~ Just mempty
         , (LW.LoggerName "Client", mkTree "Client.log")
         ]
 
--- | Helper to execute some action within $ExecM monad
+-- | Helper to execute some action within 'ExecM' monad
 withLogger :: Maybe FilePath -> ExecM () -> IO ()
 withLogger mConfigPath action = do
     cfg <- case mConfigPath of


### PR DESCRIPTION
Twin PR in snowdrop: https://github.com/serokell/snowdrop/pull/113


Split `DbAccess` to following data types:

```
data DbAccess id value res
    = DbQuery (StateR id) (StateP id value -> res)
    | DbIterator Prefix (FoldF (id, value) res)

data DbAccessM chgAccum id value res
    = DbModifyAccum
        (OldestFirst [] (ChangeSet id value))
        (Either (CSMappendException id) (OldestFirst [] chgAccum) -> res)
    | DbAccess (DbAccess id value res)
                                                                                                                                                                                                                                                              
data DbAccessU chgAccum undo id value res
    = DbModifyAccumUndo
        (NewestFirst [] undo)
        (Either (CSMappendException id) chgAccum -> res)
    | DbComputeUndo
        chgAccum
        (Either (CSMappendException id) undo -> res)
    | DbAccessM (DbAccessM chgAccum id value res)
```

See [docs/proposals/sd-112-block-handling-rewrite.md](https://github.com/serokell/snowdrop/blob/georgeee/sd-164-block-rewrite-plan/docs/proposals/sd-112-block-handling-rewrite.md) for details.