### PR TITLE
[SD-192] Introduce universal conf param

### DIFF
--- a/snowdrop-block/src/Snowdrop/Block/Application.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Application.hs
@@ -47,7 +47,7 @@ applyBlock
     :: forall blkType e m
     . ( MonadError e m
       , Eq (BlockRef blkType)
-      , HasException e (BlockApplicationException (BlockRef blkType))
+      , HasReview e (BlockApplicationException (BlockRef blkType))
       , HasGetter (RawBlk blkType) (RawPayload blkType)
       )
     => OSParams blkType
@@ -61,7 +61,7 @@ expandAndApplyBlock
     :: forall blkType e m
     . ( MonadError e m
       , Eq (BlockRef blkType)
-      , HasException e (BlockApplicationException (BlockRef blkType))
+      , HasReview e (BlockApplicationException (BlockRef blkType))
       , HasGetter (RawBlk blkType) (RawPayload blkType)
       )
     => Bool
@@ -77,7 +77,7 @@ applyBlockImpl
     :: forall blkType e m
     . ( MonadError e m
       , Eq (BlockRef blkType)
-      , HasException e (BlockApplicationException (BlockRef blkType))
+      , HasReview e (BlockApplicationException (BlockRef blkType))
       )
     => Bool
     -> OSParams blkType
@@ -120,7 +120,7 @@ tryApplyFork
       -- 4. apply appropriate chain
       , HasGetter (RawBlk blkType) (RawPayload blkType)
       , Eq (BlockRef blkType)
-      , HasExceptions e [ ForkVerificationException (BlockRef blkType)
+      , HasReviews e [ ForkVerificationException (BlockRef blkType)
                         , BlockApplicationException (BlockRef blkType)]
       , MonadError e m
       )

--- a/snowdrop-block/src/Snowdrop/Block/Demo.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Demo.hs
@@ -10,9 +10,9 @@ import           Snowdrop.Block.Configuration (BlkConfiguration (..), getCurrent
                                                getPreviousBlockRef)
 import           Snowdrop.Block.Fork (ForkVerificationException (..))
 import           Snowdrop.Block.StateConfiguration (BlkStateConfiguration (..))
-import           Snowdrop.Block.Types (BlockRef, BlockUndo, CurrentBlockRef (..), PrevBlockRef (..),
-                                       RawBlk, RawBlund)
-import           Snowdrop.Core (DbAccessU, ERwComp)
+import           Snowdrop.Block.Types (BlockRef, CurrentBlockRef (..), PrevBlockRef (..), RawBlk,
+                                       RawBlund)
+import           Snowdrop.Core (ChgAccum, DbAccessU, ERwComp, HasBException)
 import           Snowdrop.Util
 
 
@@ -20,12 +20,13 @@ import           Snowdrop.Util
 -- Client calls 'blockSync' on list of hashes of blocks to check
 -- whether server contains the same list of hashes or not
 blockSync
-  :: forall blkType e xs blockChgAccum ctx erwcomp.
+  :: forall blkType conf xs blockChgAccum erwcomp.
     ( Default blockChgAccum
-    , HasException e (ForkVerificationException (BlockRef blkType))
+    , HasBException conf (ForkVerificationException (BlockRef blkType))
     , HasGetter (RawBlund blkType) (RawBlk blkType)
     , Eq (BlockRef blkType)
-    , erwcomp ~ ERwComp e (DbAccessU blockChgAccum (BlockUndo blkType) xs) ctx blockChgAccum
+    , ChgAccum conf ~ blockChgAccum
+    , erwcomp ~ ERwComp conf (DbAccessU conf xs) blockChgAccum
     )
     => BlkStateConfiguration blkType erwcomp
     -> OldestFirst [] (BlockRef blkType)

--- a/snowdrop-block/src/Snowdrop/Block/Fork.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Fork.hs
@@ -77,7 +77,7 @@ verifyFork
     :: forall blkType e m .
        ( MonadError e m
        , Eq (BlockRef blkType)
-       , HasException e (ForkVerificationException (BlockRef blkType))
+       , HasReview e (ForkVerificationException (BlockRef blkType))
        )
     => BlkStateConfiguration blkType m
     -> OSParams blkType

--- a/snowdrop-block/src/Snowdrop/Block/State.hs
+++ b/snowdrop-block/src/Snowdrop/Block/State.hs
@@ -24,13 +24,14 @@ import           Snowdrop.Block.Configuration (BlkConfiguration (..))
 import           Snowdrop.Block.StateConfiguration (BlkStateConfiguration (..))
 import           Snowdrop.Block.Types (Block (..), BlockHeader, BlockRef, BlockUndo, Blund (..),
                                        CurrentBlockRef (..), Payload, RawBlk, RawPayload)
-import           Snowdrop.Core (CSMappendException (..), ChgAccum, ChgAccumCtx (..), DbAccessU,
-                                ERoComp, ERwComp, HChangeSet, HUpCastableChSet, MappendHChSet,
-                                QueryERo, SomeTx, StatePException (..), StateTx (..), TxComponents,
-                                UnitedTxType, UpCastableERoM, Validator, ValueOp (..), applySomeTx,
-                                computeUndo, convertEffect, getCAOrDefault, hChangeSetFromMap,
-                                liftERoComp, modifyAccum, modifyAccumOne, modifyAccumUndo, queryOne,
-                                queryOneExists, runValidator, upcastEffERoComp, upcastEffERoCompM)
+import           Snowdrop.Core (CSMappendException (..), ChgAccum, ChgAccumCtx (..), Ctx, DbAccessU,
+                                ERoComp, ERwComp, HChangeSet, HUpCastableChSet, HasBExceptions,
+                                MappendHChSet, QueryERo, SomeTx, StatePException (..), StateTx (..),
+                                TxComponents, Undo, UnitedTxType, UpCastableERoM, Validator,
+                                ValueOp (..), applySomeTx, computeUndo, convertEffect,
+                                getCAOrDefault, hChangeSetFromMap, liftERoComp, modifyAccum,
+                                modifyAccumOne, modifyAccumUndo, queryOne, queryOneExists,
+                                runValidator, upcastEffERoComp, upcastEffERoCompM)
 import           Snowdrop.Execution (ExpandRawTxsMode, ExpandableTx, ProofNExp (..),
                                      UnionSeqExpandersInps, expandUnionRawTxs)
 import           Snowdrop.Util
@@ -64,42 +65,42 @@ type BlkProcComponents blkType (txtypes :: [*]) (c :: * -> Constraint)
                  (TxComponents (UnitedTxType txtypes))
 
 mapTxs_
-  :: forall e xs txtypes ctx c .
-    ( HasLens ctx (ChgAccumCtx ctx)
+  :: forall conf xs txtypes c .
+    ( HasLens (Ctx conf) (ChgAccumCtx conf)
     , c ~ BlkProcConstr txtypes xs
     )
-  => (forall txtype . c txtype => StateTx txtype -> ERoComp e (TxComponents txtype) ctx ())
-  -> [(ChgAccum ctx, SomeTx c)]
-  -> ERoComp e xs ctx ()
+  => (forall txtype . c txtype => StateTx txtype -> ERoComp conf (TxComponents txtype) ())
+  -> [(ChgAccum conf, SomeTx c)]
+  -> ERoComp conf xs ()
 mapTxs_ handleTxDo txsWithAccs =
     mconcat $
     flip map txsWithAccs $ \(acc, tx) ->
-    local ( lensFor .~ CAInitialized @ctx acc ) $
+    local ( lensFor .~ CAInitialized @conf acc ) $
     handleTx tx
   where
     handleTx =
       applySomeTx $ \(stx :: StateTx txtype) ->
-          upcastEffERoComp @(TxComponents txtype) @xs (handleTxDo stx)
+          upcastEffERoComp @(TxComponents txtype) @xs @conf (handleTxDo stx)
 
 -- | An implementation of `BlkStateConfiguration` on top of `ERwComp`.
 -- It uniformly accesses state and block storage (via `DataAccess` interface).
 inmemoryBlkStateConfiguration
-  :: forall blkType rawTx txtypes e ctx xs c m .
+  :: forall blkType rawTx txtypes conf xs c m .
     ( xs ~ BlkProcComponents blkType txtypes c
     , c ~ BlkProcConstr txtypes xs
-    , m ~ ERwComp e (DbAccessU (ChgAccum ctx) (BlockUndo blkType) xs) ctx (ChgAccum ctx)
-    , HasExceptions e
+    , m ~ ERwComp conf (DbAccessU conf xs) (ChgAccum conf)
+    , HasBExceptions conf
         [ StatePException
         , CSMappendException
         ]
     , Payload blkType ~ [SomeTx c]
     , Ord (BlockHeader blkType)
-    , HasLens (ChgAccum ctx) (ChgAccum ctx)
-    , HasLens ctx (ChgAccumCtx ctx)
+    , HasLens (ChgAccum conf) (ChgAccum conf)
+    , HasLens (Ctx conf) (ChgAccumCtx conf)
     , HasGetter (RawBlk blkType) [rawTx]
     , HasGetter (Payload blkType) [SomeTx (BlkProcConstr txtypes xs)]
-    , Default (ChgAccum ctx)
-    , ExpandRawTxsMode e ctx txtypes
+    , Default (ChgAccum conf)
+    , ExpandRawTxsMode conf txtypes
     , MappendHChSet xs
 
     , QueryERo xs (TipComponent blkType)
@@ -108,10 +109,11 @@ inmemoryBlkStateConfiguration
     , HUpCastableChSet '[BlundComponent blkType] xs
     , UpCastableERoM (UnionSeqExpandersInps txtypes) xs
     , Default (HChangeSet xs)
+    , Undo conf ~ BlockUndo blkType
     )
     => BlkConfiguration blkType
-    -> Validator e ctx txtypes
-    -> (rawTx -> SomeData (ProofNExp e ctx rawTx) (Both (ExpandableTx txtypes) c))
+    -> Validator conf txtypes
+    -> (rawTx -> SomeData (ProofNExp conf rawTx) (Both (ExpandableTx txtypes) c))
     -> (RawBlk blkType -> [SomeTx c] -> Block (BlockHeader blkType) (Payload blkType))
     -> BlkStateConfiguration blkType m
 inmemoryBlkStateConfiguration cfg validator mkProof mkBlock = fix $ \this ->
@@ -122,15 +124,15 @@ inmemoryBlkStateConfiguration cfg validator mkProof mkBlock = fix $ \this ->
           pure (mkBlock rawBlock blkPayload)
     , bscApplyPayload = \(gett @_ @[SomeTx (BlkProcConstr txtypes xs)] -> txs) -> do
           (newSt, undo) <- liftERoComp $ do
-              curAcc <- asks (getCAOrDefault @ctx . gett)
+              curAcc <- asks (getCAOrDefault @conf . gett)
               OldestFirst accs <-
-                convertEffect $ modifyAccum @_ @xs (OldestFirst $ map (applySomeTx $ hupcast . txBody) txs)
+                  convertEffect @conf $ modifyAccum @xs @conf (OldestFirst $ map (applySomeTx $ hupcast . txBody) txs)
               let preAccs = init (curAcc :| accs)
                   lastAcc = last (curAcc :| accs)
-              convertEffect $ mapTxs_ (runValidator validator) (zip preAccs txs)
-              (lastAcc,) <$> computeUndo @_ @xs lastAcc
+              convertEffect @conf $ mapTxs_ @conf (runValidator validator) (zip preAccs txs)
+              (lastAcc,) <$> computeUndo @xs @conf lastAcc
           undo <$ modify (flip sett newSt)
-     , bscApplyUndo = liftERoComp . modifyAccumUndo @_ @xs . pure >=> modify . flip sett
+     , bscApplyUndo = liftERoComp . modifyAccumUndo @xs @conf . pure >=> modify . flip sett
      , bscStoreBlund = \blund -> do
            let blockRef = unCurrentBlockRef $ bcBlockRef cfg (blkHeader $ buBlock blund)
            let chg = hChangeSetFromMap @(BlundComponent blkType) $ M.singleton blockRef (New blund)
@@ -138,9 +140,9 @@ inmemoryBlkStateConfiguration cfg validator mkProof mkBlock = fix $ \this ->
      , bscRemoveBlund = \blockRef -> do
            let chg = hChangeSetFromMap @(BlundComponent blkType) $ M.singleton blockRef Rem
            applyBlkChg chg
-     , bscGetBlund = liftERoComp . queryOne @(BlundComponent blkType) @xs
-     , bscBlockExists = liftERoComp . queryOneExists @(BlundComponent blkType) @xs
-     , bscGetTip = unTipValue <<$>> liftERoComp (queryOne @(TipComponent blkType) @xs TipKey)
+     , bscGetBlund = liftERoComp . queryOne @(BlundComponent blkType) @xs @conf
+     , bscBlockExists = liftERoComp . queryOneExists @(BlundComponent blkType) @xs @conf
+     , bscGetTip = unTipValue <<$>> liftERoComp (queryOne @(TipComponent blkType) @xs @conf TipKey)
      , bscSetTip = \newTip' -> do
            oldTip <- bscGetTip this
            let applyChg tipMod = applyBlkChg $ hChangeSetFromMap @(TipComponent blkType) $ M.singleton TipKey tipMod
@@ -153,5 +155,5 @@ inmemoryBlkStateConfiguration cfg validator mkProof mkBlock = fix $ \this ->
     where
       applyBlkChg :: forall t . HUpCastableChSet '[t] xs => HChangeSet '[t] -> m ()
       applyBlkChg chg =
-          liftERoComp (modifyAccumOne @_ @xs $ hupcast @_ @'[t] @xs chg)
+          liftERoComp (modifyAccumOne @xs @conf $ hupcast @_ @'[t] @xs chg)
               >>= modify . flip sett

--- a/snowdrop-core/snowdrop-core.cabal
+++ b/snowdrop-core/snowdrop-core.cabal
@@ -136,8 +136,6 @@ test-suite snowdrop-core-test
       Spec
       Test.Snowdrop.Core.ChangeSet
       Test.Snowdrop.Core.Executor
-      -- Test.Snowdrop.Core.Free
-      -- Test.Snowdrop.Core.Types
   default-language: Haskell2010
   default-extensions:   NoImplicitPrelude
                         OverloadedStrings

--- a/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 -- | Basic types and functions for Exceptionable Read-Write Computation.
 
 module Snowdrop.Core.ERwComp
@@ -13,27 +15,29 @@ import           Universum
 import           Control.Monad.Except (MonadError)
 
 import           Snowdrop.Core.BaseM (BaseM)
-import           Snowdrop.Core.ERoComp (ChgAccum, ChgAccumCtx (..), ConvertEffect (..), DbAccessM,
-                                        StatePException (..), UpCastableERoM, initAccumCtx,
-                                        upcastEffERoCompM)
+import           Snowdrop.Core.ERoComp (BException, ChgAccum, ChgAccumCtx (..), ConvertEffect (..),
+                                        Ctx, DbAccessM, HasBException, StatePException (..),
+                                        UpCastableERoM, initAccumCtx, upcastEffERoCompM)
 import           Snowdrop.Util
 
 -- | StateT over ERoComp.
 -- ERoComp can be lifted to ERwComp with regarding a current state.
-newtype ERwComp e eff ctx s a = ERwComp { unERwComp :: StateT s (BaseM e eff ctx) a }
-    deriving (Functor, Applicative, Monad, MonadError e, MonadState s)
+newtype ERwComp conf eff s a = ERwComp { unERwComp :: StateT s (BaseM (BException conf) eff (Ctx conf)) a }
+    deriving (Functor, Applicative, Monad, MonadState s)
+
+deriving instance e ~ BException conf => MonadError e (ERwComp conf eff s)
 
 -- | Run a ERwComp with a passed initial state.
 runERwComp
-  :: forall e eff ctx s a.
-    ( HasException e StatePException
-    , HasGetter ctx (ChgAccumCtx ctx)
+  :: forall conf eff s a.
+    ( HasBException conf StatePException
+    , HasGetter (Ctx conf) (ChgAccumCtx conf)
     )
-  => ERwComp e eff ctx s a
+  => ERwComp conf eff s a
   -> s
-  -> BaseM e eff ctx (a, s)
+  -> BaseM (BException conf) eff (Ctx conf) (a, s)
 runERwComp stComp initS = do
-    mChgAccum <- asks (gett @_ @(ChgAccumCtx ctx))
+    mChgAccum <- asks (gett @_ @(ChgAccumCtx conf))
     case mChgAccum of
         CANotInitialized -> pure ()
         CAInitialized _  -> throwLocalError ChgAccumCtxUnexpectedlyInitialized
@@ -42,23 +46,28 @@ runERwComp stComp initS = do
 -- | Lift passed ERoComp to ERwComp.
 -- Set initial state of ERoComp as ChgAccum from state from ERwComp.
 liftERoComp
-    :: forall e eff2 ctx s eff1 a.
-    ( HasException e StatePException
-    , HasLens ctx (ChgAccumCtx ctx)
-    , HasGetter s (ChgAccum ctx)
-    , ConvertEffect e ctx eff1 eff2
+    :: forall conf eff2 s eff1 a.
+    ( HasBException conf StatePException
+    , HasLens (Ctx conf) (ChgAccumCtx conf)
+    , HasGetter s (ChgAccum conf)
+    , ConvertEffect conf eff1 eff2
     )
-    => BaseM e eff1 ctx a
-    -> ERwComp e eff2 ctx s a
+    => BaseM (BException conf) eff1 (Ctx conf) a
+    -> ERwComp conf eff2 s a
 liftERoComp comp =
-    gets (gett @_ @(ChgAccum ctx)) >>= ERwComp . lift . flip initAccumCtx (convertEffect comp)
+    gets (gett @_ @(ChgAccum conf)) >>=
+        ERwComp . lift . flip (initAccumCtx @_ @conf) (convertEffect @conf comp)
 
-convertERwComp :: (BaseM e eff1 ctx (a, s) -> BaseM e eff2 ctx (a, s)) -> ERwComp e eff1 ctx s a -> ERwComp e eff2 ctx s a
+convertERwComp
+  :: forall conf eff1 eff2 s a .
+     ( BaseM (BException conf) eff1 (Ctx conf) (a, s)
+        -> BaseM (BException conf) eff2 (Ctx conf) (a, s) )
+  -> ERwComp conf eff1 s a -> ERwComp conf eff2 s a
 convertERwComp f (ERwComp (StateT act)) = ERwComp $ StateT $ \s -> f (act s)
 
 upcastEffERwCompM
-    :: forall xs supxs e ctx s a . UpCastableERoM xs supxs
-    => ERwComp e (DbAccessM (ChgAccum ctx) xs) ctx s a
-    -> ERwComp e (DbAccessM (ChgAccum ctx) supxs) ctx s a
+    :: forall xs supxs conf s a . UpCastableERoM xs supxs
+    => ERwComp conf (DbAccessM conf xs) s a
+    -> ERwComp conf (DbAccessM conf supxs) s a
 upcastEffERwCompM (ERwComp comp) = ERwComp $ StateT $ upcastEffERoCompM . runStateT comp
 

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/AVLp/Accum.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/AVLp/Accum.hs
@@ -36,8 +36,7 @@ import           Snowdrop.Execution.DbActions.AVLp.Avl (AllAvlEntries, AvlHashab
                                                         RootHashes, avlRootHash, mkAVL)
 import           Snowdrop.Execution.DbActions.AVLp.State (AVLCache, AVLCacheT, RetrieveImpl,
                                                           reThrowAVLEx, runAVLCacheT)
-import           Snowdrop.Execution.DbActions.Types (DGetter, DIter, DIter', DModify,
-                                                     IterAction (..))
+import           Snowdrop.Execution.DbActions.Types (DGetter', DIter', DModify', IterAction (..))
 import           Snowdrop.Util (HKey, HMap, HMapEl (..), HSet, HSetEl (..), HVal, HasGetter (..),
                                 Head, NewestFirst (..), OldestFirst (..), RecAll')
 
@@ -78,7 +77,8 @@ modAccum
     , AllAvlEntries h xs
     )
     => ctx
-    -> DModify (AVLChgAccums h xs) xs m
+    -> AVLChgAccums h xs
+    -> DModify' (AVLChgAccums h xs) xs m
 modAccum ctx acc' cs' = fmap Just <<$>> case acc' of
     Just acc -> modAccumAll acc cs'
     Nothing  -> modAccumAll (resolveAvlCA ctx acc') cs'
@@ -174,7 +174,7 @@ query
     , MonadIO m, MonadCatch m
     , AllAvlEntries h xs
     )
-    => ctx -> DGetter (AVLChgAccums h xs) xs m
+   => ctx -> AVLChgAccums h xs -> DGetter' xs m
 query ctx (Just ca) hset = queryAll ca hset
   where
     queryAll :: forall rs . RecAll' rs (IsAvlEntry h) => Rec (AVLChgAccum h) rs -> HSet rs -> m (HMap rs)
@@ -203,7 +203,8 @@ iter
     , AllAvlEntries h xs
     )
     => ctx
-    -> DIter (AVLChgAccums h xs) xs m
+    -> AVLChgAccums h xs
+    -> m (DIter' xs m)
 iter ctx (Just ca) = pure $ iterAll ca
   where
     iterAll :: forall rs . RecAll' rs (IsAvlEntry h) => Rec (AVLChgAccum h) rs -> DIter' rs m

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/AVLp/Actions.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/AVLp/Actions.hs
@@ -20,6 +20,7 @@ import qualified Data.Map.Strict as M
 import           Data.Vinyl (Rec (..))
 import           Data.Vinyl.Recursive (rmap)
 
+import           Snowdrop.Core (ChgAccum, Undo)
 import           Snowdrop.Execution.DbActions.AVLp.Accum (AVLChgAccum (..), AVLChgAccums,
                                                           RootHashes, computeUndo, iter, modAccum,
                                                           modAccumU, query)
@@ -35,34 +36,38 @@ import           Snowdrop.Execution.DbActions.AVLp.State (AMSRequested (..), AVL
                                                           clientModeToTempSt, runAVLCacheT)
 import           Snowdrop.Execution.DbActions.Types (ClientMode (..), DbAccessActions (..),
                                                      DbAccessActionsM (..), DbAccessActionsU (..),
-                                                     DbActionsException (..), DbModifyActions (..),
-                                                     RememberForProof (..))
-import           Snowdrop.Util (HKey, HVal, HasPrism, NewestFirst, inj, proj, unHSetEl)
+                                                     DbApplyProof, DbComponents,
+                                                     DbModifyActions (..), RememberForProof (..))
+import           Snowdrop.Util (HKey, HVal, NewestFirst, unHSetEl)
 
 avlClientDbActions
-    :: forall h xs undo m n .
+    :: forall h conf m n xs .
     ( MonadIO m, MonadCatch m, MonadIO n, MonadCatch n
     , AvlHashable h
     , RetrieveImpl (ReaderT (ClientTempState h xs n) m) h
     , AllAvlEntries h xs
-    , HasPrism undo (AvlUndo h xs)
+
+    , Undo conf ~ AvlUndo h xs
+    , ChgAccum conf ~ AVLChgAccums h xs
+    , DbApplyProof conf ~ ()
+    , xs ~ DbComponents conf
     )
     => RetrieveF h n
     -> RootHashes h xs
-    -> n (ClientMode (AvlProofs h xs) -> DbModifyActions (AVLChgAccums h xs) undo xs m ())
+    -> n (ClientMode (AvlProofs h xs) -> DbModifyActions conf m)
 avlClientDbActions retrieveF = fmap mkActions . newTVarIO
   where
     mkActions
         :: TVar (RootHashes h xs)
         -> ClientMode (AvlProofs h xs)
-        -> DbModifyActions (AVLChgAccums h xs) undo xs m ()
+        -> DbModifyActions conf m
     mkActions var ctMode =
         DbModifyActions (mkAccessActions var ctMode) (apply var)
 
     mkAccessActions
         :: TVar (RootHashes h xs)
         -> ClientMode (AvlProofs h xs)
-        -> DbAccessActionsU (AVLChgAccums h xs) undo xs  m
+        -> DbAccessActionsU conf m
     mkAccessActions var ctMode = daaU
       where
         daa =
@@ -75,7 +80,7 @@ avlClientDbActions retrieveF = fmap mkActions . newTVarIO
         daaM = DbAccessActionsM daa (\cA cs -> createState >>= \ctx -> modAccum ctx cA cs)
         daaU = DbAccessActionsU daaM
                   (withProjUndo . modAccumU)
-                  (\cA _cs -> pure . Right . inj . computeUndo cA =<< createState)
+                  (\cA _cs -> pure . Right . computeUndo cA =<< createState)
         createState = clientModeToTempSt retrieveF ctMode =<< atomically (readTVar var)
 
     apply :: AvlHashable h => TVar (RootHashes h xs) -> AVLChgAccums h xs -> m ()
@@ -83,20 +88,24 @@ avlClientDbActions retrieveF = fmap mkActions . newTVarIO
         liftIO $ atomically $ writeTVar var $ rmap (RootHashComp . avlRootHash . acaMap) accums
     apply _ Nothing = pure ()
 
-withProjUndo :: (HasPrism undo undo', MonadThrow m, Applicative f) => (NewestFirst [] undo' -> a) -> NewestFirst [] undo -> m (f a)
-withProjUndo action = maybe (throwM DbUndoProjectionError) (pure . pure . action) . traverse proj
+withProjUndo :: (MonadThrow m, Applicative f) => (NewestFirst [] undo -> a) -> NewestFirst [] undo -> m (f a)
+withProjUndo action = pure . pure . action
 
 avlServerDbActions
-    :: forall xs h m n undo .
+    :: forall conf h m n xs .
     ( MonadIO m, MonadCatch m, AvlHashable h, MonadIO n
     , AllAvlEntries h xs
 
     , AllWholeTree xs
     , Monoid (Rec AMSRequested xs)
-    , HasPrism undo (AvlUndo h xs)
+
+    , Undo conf ~ AvlUndo h xs
+    , ChgAccum conf ~ AVLChgAccums h xs
+    , DbApplyProof conf ~ AvlProofs h xs
+    , xs ~ DbComponents conf
     )
     => AVLServerState h xs
-    -> n ( RememberForProof -> DbModifyActions (AVLChgAccums h xs) undo xs m (AvlProofs h xs)
+    -> n ( RememberForProof -> DbModifyActions conf m
             -- `DbModifyActions` provided by `RememberForProof` object
             -- (`RememberForProof False` for disabling recording for queries performed)
           , RetrieveF h n
@@ -127,7 +136,7 @@ avlServerDbActions = fmap mkActions . newTVarIO
         daaM = DbAccessActionsM daa (\cA cs -> liftIO (atomically (readTVar var)) >>= \ctx -> modAccum ctx cA cs)
         daaU = DbAccessActionsU daaM
                   (withProjUndo . modAccumU)
-                  (\cA _cs -> pure . Right . inj . computeUndo cA =<< atomically (readTVar var))
+                  (\cA _cs -> pure . Right . computeUndo cA =<< atomically (readTVar var))
 
     retrieveAMS
         :: Monoid (Rec AMSRequested xs)

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/AVLp/Actions.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/AVLp/Actions.hs
@@ -41,7 +41,7 @@ import           Snowdrop.Execution.DbActions.Types (ClientMode (..), DbAccessAc
 import           Snowdrop.Util (HKey, HVal, NewestFirst, unHSetEl)
 
 avlClientDbActions
-    :: forall h conf m n xs .
+    :: forall conf h m n xs .
     ( MonadIO m, MonadCatch m, MonadIO n, MonadCatch n
     , AvlHashable h
     , RetrieveImpl (ReaderT (ClientTempState h xs n) m) h

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/Composite.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/Composite.hs
@@ -4,6 +4,8 @@ module Snowdrop.Execution.DbActions.Composite
        , constructCompositeDaaM
        , constructCompositeDaaU
        , CompositeChgAccum (..)
+       , CompositeUndo (..)
+       , CompositeConf
        ) where
 
 import           Universum
@@ -11,31 +13,45 @@ import           Universum
 import           Data.Default (Default (def))
 import           Data.Vinyl.TypeLevel (type (++))
 
-import           Snowdrop.Core (CSMappendException)
+import           Snowdrop.Core (CSMappendException, ChgAccum, Undo)
 import           Snowdrop.Execution.DbActions.Types
 import           Snowdrop.Util (HDownCastable, NewestFirst (..), NotIntersect, OldestFirst (..),
                                 happend, hdowncast)
 
-data CompositeChgAccum chgAccumPrimary chgAccumSecondary = CompositeChgAccum
-    { ccaPrimary   :: chgAccumPrimary
-    , ccaSecondary :: chgAccumSecondary
+data CompositeConf conf1 conf2
+
+type instance Undo (CompositeConf conf1 conf2) = CompositeUndo conf1 conf2
+type instance ChgAccum (CompositeConf conf1 conf2) = CompositeChgAccum conf1 conf2
+type instance DbComponents (CompositeConf conf1 conf2) = DbComponents conf1 ++ DbComponents conf2
+
+data CompositeUndo conf1 conf2 = CompositeUndo
+    { cuPrimary   :: Undo conf1
+    , cuSecondary :: Undo conf2
     }
 
-instance (Default chgAccumPrimary, Default chgAccumSecondary)
-         => Default (CompositeChgAccum chgAccumPrimary chgAccumSecondary) where
+data CompositeChgAccum conf1 conf2 = CompositeChgAccum
+    { ccaPrimary   :: ChgAccum conf1
+    , ccaSecondary :: ChgAccum conf2
+    }
+
+instance (Default (ChgAccum conf1), Default (ChgAccum conf2))
+         => Default (CompositeChgAccum conf1 conf2) where
     def = CompositeChgAccum def def
 
 constructCompositeDaa
-    :: forall caPrimary caSecondary components1 components2 m .
+    :: forall conf1 conf2 m components1 components2 .
     ( Monad m
+    , components1 ~ DbComponents conf1
+    , components2 ~ DbComponents conf2
+
     , NotIntersect components1 components2
 
     , HDownCastable (components1 ++ components2) components1
     , HDownCastable (components1 ++ components2) components2
     )
-    => DbAccessActions caPrimary components1 m
-    -> DbAccessActions caSecondary components2 m
-    -> DbAccessActions (CompositeChgAccum caPrimary caSecondary) (components1 ++ components2) m
+    => DbAccessActions conf1 m
+    -> DbAccessActions conf2 m
+    -> DbAccessActions (CompositeConf conf1 conf2) m
 constructCompositeDaa dbaP dbaS = DbAccessActions {
     daaGetter = \(CompositeChgAccum prim sec) reqs ->
           liftA2 happend (daaGetter dbaP prim (hdowncast reqs)) (daaGetter dbaS sec (hdowncast reqs))
@@ -43,16 +59,19 @@ constructCompositeDaa dbaP dbaS = DbAccessActions {
   }
 
 constructCompositeDaaM
-    :: forall caPrimary caSecondary components1 components2 m .
+    :: forall conf1 conf2 m components1 components2 .
     ( Monad m
+    , components1 ~ DbComponents conf1
+    , components2 ~ DbComponents conf2
+
     , NotIntersect components1 components2
 
     , HDownCastable (components1 ++ components2) components1
     , HDownCastable (components1 ++ components2) components2
     )
-    => DbAccessActionsM caPrimary components1 m
-    -> DbAccessActionsM caSecondary components2 m
-    -> DbAccessActionsM (CompositeChgAccum caPrimary caSecondary) (components1 ++ components2) m
+    => DbAccessActionsM conf1 m
+    -> DbAccessActionsM conf2 m
+    -> DbAccessActionsM (CompositeConf conf1 conf2) m
 constructCompositeDaaM dbaP dbaS = DbAccessActionsM {
     daaAccess = constructCompositeDaa (daaAccess dbaP) (daaAccess dbaS)
   , daaModifyAccum = modifyAccum
@@ -66,21 +85,21 @@ constructCompositeDaaM dbaP dbaS = DbAccessActionsM {
         glue (OldestFirst accsP) (OldestFirst accsS) =
             OldestFirst $ uncurry CompositeChgAccum <$> zip accsP accsS
 
--- TODO re-consider how undo is constructed (remove constructUndo/splitUndo)
 constructCompositeDaaU
-  :: forall caPrimary caSecondary undoPrimary undoSecondary undo components1 components2 m .
+    :: forall conf1 conf2 m components1 components2 .
     ( Monad m
+    , components1 ~ DbComponents conf1
+    , components2 ~ DbComponents conf2
+
     , NotIntersect components1 components2
 
     , HDownCastable (components1 ++ components2) components1
     , HDownCastable (components1 ++ components2) components2
     )
-    => DbAccessActionsU caPrimary undoPrimary components1 m
-    -> DbAccessActionsU caSecondary undoSecondary components2 m
-    -> (undoPrimary -> undoSecondary -> undo)
-    -> (undo -> (undoPrimary, undoSecondary))
-    -> DbAccessActionsU (CompositeChgAccum caPrimary caSecondary) undo (components1 ++ components2) m
-constructCompositeDaaU dbaP dbaS constructUndo splitUndo = DbAccessActionsU {
+    => DbAccessActionsU conf1 m
+    -> DbAccessActionsU conf2 m
+    -> DbAccessActionsU (CompositeConf conf1 conf2) m
+constructCompositeDaaU dbaP dbaS = DbAccessActionsU {
     daaAccessM = constructCompositeDaaM (daaAccessM dbaP) (daaAccessM dbaS)
   , daaModifyAccumUndo = modifyAccumU
   , daaComputeUndo = computeUndo
@@ -88,17 +107,18 @@ constructCompositeDaaU dbaP dbaS constructUndo splitUndo = DbAccessActionsU {
   where
 
     modifyAccumU
-      :: CompositeChgAccum caPrimary caSecondary
-      -> NewestFirst [] undo
-      -> m (Either CSMappendException (CompositeChgAccum caPrimary caSecondary))
+      :: CompositeChgAccum conf1 conf2
+      -> NewestFirst [] (CompositeUndo conf1 conf2)
+      -> m (Either CSMappendException (CompositeChgAccum conf1 conf2))
     modifyAccumU (CompositeChgAccum cP cS) (NewestFirst us) =
         liftA2 CompositeChgAccum <$> daaModifyAccumUndo dbaP cP usP <*> daaModifyAccumUndo dbaS cS usS
       where
         (usP, usS) = bimap NewestFirst NewestFirst $ unzip $ splitUndo <$> us
+        splitUndo (CompositeUndo uP uS) = (uP, uS)
 
     computeUndo
-      :: CompositeChgAccum caPrimary caSecondary
-      -> CompositeChgAccum caPrimary caSecondary
-      -> m (Either CSMappendException undo)
+      :: CompositeChgAccum conf1 conf2
+      -> CompositeChgAccum conf1 conf2
+      -> m (Either CSMappendException (CompositeUndo conf1 conf2))
     computeUndo (CompositeChgAccum cP cS) (CompositeChgAccum cP' cS') =
-        liftA2 constructUndo <$> daaComputeUndo dbaP cP cP' <*> daaComputeUndo dbaS cS cS'
+        liftA2 CompositeUndo <$> daaComputeUndo dbaP cP cP' <*> daaComputeUndo dbaS cS cS'

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/Types.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/Types.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE InstanceSigs        #-}
 {-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Snowdrop.Execution.DbActions.Types
        (
-         DbAccessActions (..)
+         DbComponents
+       , DbApplyProof
+       , DbAccessActions (..)
        , DbAccessActionsM (..)
        , DbAccessActionsU (..)
        , IterAction (..)
@@ -13,6 +16,7 @@ module Snowdrop.Execution.DbActions.Types
        , DIter
        , DIter'
        , DModify
+       , DModify'
        , DbModifyActions (..)
        , DbActionsException (..)
        , RememberForProof (..)
@@ -24,38 +28,54 @@ import           Universum
 
 import qualified Data.Text.Buildable
 import           Data.Vinyl.Core (Rec)
+import           Data.Vinyl.Recursive (rmap)
 import           Formatting (bprint, build, (%))
 
-import           Snowdrop.Core (CSMappendException (..), DbAccess (..), DbAccessM (..),
-                                DbAccessU (..), FoldF (..), HChangeSet)
-import           Snowdrop.Util (HKey, HMap, HSet, HVal, NewestFirst, OldestFirst)
+import           Snowdrop.Core (CSMappendException (..), ChgAccum, DbAccess (..), DbAccessM (..),
+                                DbAccessU (..), FoldF (..), HChangeSet, Undo)
+import           Snowdrop.Util (HFunctor (..), HKey, HMap, HSet, HVal, NewestFirst, OldestFirst)
+
+type family DbComponents conf :: [*]
+type family DbApplyProof conf :: *
 
 type DGetter' xs m = HSet xs -> m (HMap xs)
-type DGetter chgAccum xs m = chgAccum -> DGetter' xs m
+type DGetter conf m = ChgAccum conf -> DGetter' (DbComponents conf) m
 
-type DModify chgAccum xs m = chgAccum -> OldestFirst [] (HChangeSet xs) -> m (Either CSMappendException (OldestFirst [] chgAccum))
-type DModifyUndo chgAccum undo m = chgAccum -> NewestFirst [] undo -> m (Either CSMappendException chgAccum)
-type DComputeUndo chgAccum undo m = chgAccum -> chgAccum -> m (Either CSMappendException undo)
+type DModify' chgAccum xs m =
+     OldestFirst [] (HChangeSet xs)
+  -> m (Either CSMappendException (OldestFirst [] chgAccum))
+
+type DModify conf m = ChgAccum conf -> DModify' (ChgAccum conf) (DbComponents conf) m
+
+type DModifyUndo conf m =
+       ChgAccum conf
+    -> NewestFirst [] (Undo conf)
+    -> m (Either CSMappendException (ChgAccum conf))
+
+type DComputeUndo conf m =
+       ChgAccum conf
+    -> ChgAccum conf
+    -> m (Either CSMappendException (Undo conf))
 
 newtype IterAction m t = IterAction {runIterAction :: forall b . b -> (b -> (HKey t, HVal t) -> b) -> m b }
 type DIter' xs m = Rec (IterAction m) xs
-type DIter chgAccum xs m = chgAccum -> m (DIter' xs m)
+type DIter conf m = ChgAccum conf -> m (DIter' (DbComponents conf) m)
 
 -- | Actions to execute 'DbAccess' effect.
 -- Methods provided in the data type are not intended to modify any internal state.
-data DbAccessActions chgAccum xs m = DbAccessActions
-    { daaGetter :: DGetter chgAccum xs m
+data DbAccessActions conf m = DbAccessActions
+    { daaGetter :: DGetter conf m
     -- ^ Retrieves values corresponding to specified keys (doesn't modify the state)
-    , daaIter   :: DIter chgAccum xs m
+    , daaIter   :: DIter conf m
     -- ^ Iterate through keys with specified prefix (doesn't modify the state)
     }
 
 -- | Actions to execute 'DbAccessM' effect.
 -- Methods provided in the data type are not intended to modify any internal state.
-data DbAccessActionsM chgAccum xs m = DbAccessActionsM
-    { daaAccess      :: DbAccessActions chgAccum xs m
+data DbAccessActionsM conf m = DbAccessActionsM
+    { daaAccess      :: DbAccessActions conf m
     -- ^ Actions to execute 'DbAccess' effect.
-    , daaModifyAccum :: DModify chgAccum xs m
+    , daaModifyAccum :: DModify conf m
     -- ^ Modify change accumulator with specified list of change sets.
     -- First argument is a change accumulator to modify.
     -- Second argument is a list of change sets (in oldest first order).
@@ -65,16 +85,16 @@ data DbAccessActionsM chgAccum xs m = DbAccessActionsM
 
 -- | Actions to execute 'DbAccessU' effect.
 -- Methods provided in the data type are not intended to modify any internal state.
-data DbAccessActionsU chgAccum undo (xs :: [*]) m = DbAccessActionsU
-    { daaAccessM         :: DbAccessActionsM chgAccum xs m
+data DbAccessActionsU conf m = DbAccessActionsU
+    { daaAccessM         :: DbAccessActionsM conf m
     -- ^ Actions to execute 'DbAccessM' effect.
-    , daaModifyAccumUndo :: DModifyUndo chgAccum undo m
+    , daaModifyAccumUndo :: DModifyUndo conf m
     -- ^ Applies undos to a given accumulator.
     -- First argument is a change accumulator to modify.
     -- Second argument is a list of undo object (in newest first order).
     -- Function applies each undo to accumulator in newest first order,
     -- returns modified accumulator.
-    , daaComputeUndo     :: DComputeUndo chgAccum undo m
+    , daaComputeUndo     :: DComputeUndo conf m
     -- ^ Computes undo. First argument is a base change accumulator.
     -- Second argument is a modified change accumulator.
     -- Function returns an undo object, such that @modified `applyUndo` undo = base@
@@ -85,32 +105,35 @@ class DbActions effect actions param m where
     -- | Execute @effect r@ using @actions m@ and return value @r@ in monad @m@.
     executeEffect :: effect r -> actions m -> param -> m r
 
-instance Monad m => DbActions (DbAccess xs)
-                                (DbAccessActions chgAccum xs) chgAccum m where
-    executeEffect (DbQuery req cont) daa chgAccum =
-        cont <$> daaGetter daa chgAccum req
-    executeEffect (DbIterator getComp (FoldF (e, acc, cont))) daa chgAccum =
-        cont <$> ((\record -> runIterAction (getComp record) e acc) =<< daaIter daa chgAccum)
+instance (chgAccum ~ ChgAccum conf, Monad m, xs ~ DbComponents conf) =>
+    DbActions (DbAccess xs) (DbAccessActions conf) chgAccum m where
 
-instance Monad m => DbActions (DbAccessM chgAccum xs)
-                                (DbAccessActionsM chgAccum xs) chgAccum m where
-    executeEffect (DbAccess da) (daaAccess -> daa) chgAccum = executeEffect da daa chgAccum
-    executeEffect (DbModifyAccum chgSet cont) daaM chgAccum =
-        cont <$> daaModifyAccum daaM chgAccum chgSet
+    executeEffect (DbQuery req cont) daa conf =
+        cont <$> daaGetter daa conf req
+    executeEffect (DbIterator getComp (FoldF (e, acc, cont))) daa conf =
+        cont <$> ((\record -> runIterAction (getComp record) e acc) =<< daaIter daa conf)
 
-instance Monad m => DbActions (DbAccessU chgAccum undo xs)
-                                (DbAccessActionsU chgAccum undo xs) chgAccum m where
-    executeEffect (DbAccessM daM) (daaAccessM -> daaM) chgAccum = executeEffect daM daaM chgAccum
-    executeEffect (DbComputeUndo cs cont) daaU chgAccum =
-        cont <$> daaComputeUndo daaU chgAccum cs
+instance (chgAccum ~ ChgAccum conf, Monad m, xs ~ DbComponents conf) =>
+    DbActions (DbAccessM conf xs) (DbAccessActionsM conf) chgAccum m where
+
+    executeEffect (DbAccess da) (daaAccess -> daa) conf = executeEffect da daa conf
+    executeEffect (DbModifyAccum chgSet cont) daaM conf =
+        cont <$> daaModifyAccum daaM conf chgSet
+
+instance (chgAccum ~ ChgAccum conf, Monad m, xs ~ DbComponents conf) =>
+    DbActions (DbAccessU conf xs) (DbAccessActionsU conf) chgAccum m where
+
+    executeEffect (DbAccessM daM) (daaAccessM -> daaM) conf = executeEffect daM daaM conf
+    executeEffect (DbComputeUndo cs cont) daaU conf =
+        cont <$> daaComputeUndo daaU conf cs
     executeEffect (DbModifyAccumUndo undos cont) daaU chgAccum =
-        cont <$> daaModifyAccumUndo daaU chgAccum undos
+      cont <$> daaModifyAccumUndo daaU chgAccum undos
 
 -- | Actions to access and modify state.
-data DbModifyActions chgAccum undo xs m proof = DbModifyActions
-    { dmaAccess :: DbAccessActionsU chgAccum undo xs m
+data DbModifyActions conf m = DbModifyActions
+    { dmaAccess :: DbAccessActionsU conf m
     -- ^ Actions to execute 'DbAccessU' effect.
-    , dmaApply  :: chgAccum -> m proof
+    , dmaApply  :: ChgAccum conf -> m (DbApplyProof conf)
     -- ^ Apply provided change accumulator to internal state
     -- and return proof of the internal state change.
     -- This proof is further to be used on light client
@@ -142,3 +165,41 @@ data RememberForProof = RememberForProof { unRememberForProof :: Bool }
 data ClientMode proof
     = ProofMode { cmProof :: proof }
     | RemoteMode
+
+instance HFunctor (DbAccessActions conf) where
+    fmapH
+      :: forall m n .
+        Functor m
+      => (forall x . m x -> n x)
+      -> DbAccessActions conf m
+      -> DbAccessActions conf n
+    fmapH f (DbAccessActions {..}) =
+      DbAccessActions
+        { daaGetter = f ... daaGetter
+        , daaIter = f . fmap (rmap fIterAction) . daaIter
+        }
+      where
+        fIterAction :: IterAction m t -> IterAction n t
+        fIterAction (IterAction g) = IterAction (f ... g)
+
+instance HFunctor (DbAccessActionsM conf) where
+    fmapH f (DbAccessActionsM {..}) =
+      DbAccessActionsM
+        { daaAccess = fmapH f daaAccess
+        , daaModifyAccum = f ... daaModifyAccum
+        }
+
+instance HFunctor (DbAccessActionsU conf) where
+    fmapH f (DbAccessActionsU {..}) =
+      DbAccessActionsU
+        { daaAccessM = fmapH f daaAccessM
+        , daaModifyAccumUndo = f ... daaModifyAccumUndo
+        , daaComputeUndo = f ... daaComputeUndo
+        }
+
+instance HFunctor (DbModifyActions conf) where
+    fmapH f (DbModifyActions {..}) =
+      DbModifyActions
+        { dmaAccess = fmapH f dmaAccess
+        , dmaApply = f ... dmaApply
+        }

--- a/snowdrop-execution/src/Snowdrop/Execution/DbActions/Types.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/DbActions/Types.hs
@@ -146,7 +146,6 @@ data DbActionsException
     | DbWrongIdQuery Text
     | DbWrongPrefixIter Text
     | DbProtocolError Text
-    | DbUndoProjectionError
     deriving Show
 
 instance Exception DbActionsException
@@ -157,7 +156,6 @@ instance Buildable DbActionsException where
         DbWrongIdQuery t -> bprint ("Wrong id query to DB: "%build) t
         DbWrongPrefixIter t -> bprint ("Wrong prefix iterator: "%build) t
         DbProtocolError t -> bprint ("Db protocol error: "%build) t
-        DbUndoProjectionError -> "Wrong undo object provided: projection failed"
 
 -- | Toggle on whether to record proof within DbModifyActions
 data RememberForProof = RememberForProof { unRememberForProof :: Bool }

--- a/snowdrop-execution/src/Snowdrop/Execution/Mempool/Core.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/Mempool/Core.hs
@@ -23,30 +23,31 @@ import           Universum
 import           Control.Lens (lens)
 import           Data.Default (Default (..))
 
-import           Snowdrop.Core (CSMappendException, ChgAccum, ChgAccumCtx, ConvertEffect, DbAccessM,
-                                ERwComp, ProofNExp, StatePException, StateTx (..), TxComponents,
-                                UpCastableERoM, Validator, convertERwComp, convertEffect,
-                                liftERoComp, modifyAccumOne, runValidator)
+import           Snowdrop.Core (BException, CSMappendException, ChgAccum, ChgAccumCtx,
+                                ConvertEffect, Ctx, DbAccessM, ERwComp, HasBException,
+                                HasBExceptions, ProofNExp, StatePException, StateTx (..),
+                                TxComponents, UpCastableERoM, Validator, convertERwComp,
+                                convertEffect, liftERoComp, modifyAccumOne, runValidator)
 import           Snowdrop.Execution.DbActions (DbActions)
 import           Snowdrop.Execution.Expand (ExpandOneTxMode, expandOneTx)
-import           Snowdrop.Execution.IOExecutor (IOCtx, runERwCompIO)
+import           Snowdrop.Execution.IOExecutor (IOCtx, IOExecEffect, runERwCompIO)
 import           Snowdrop.Util
 
 ---------------------------
 -- Core part
 ---------------------------
 
-type RwMempoolAct e xs ctx rawtx a =
-    ERwComp e (DbAccessM (ChgAccum ctx) xs) ctx (MempoolState (ChgAccum ctx) rawtx) a
+type RwMempoolAct conf xs rawtx a =
+    ERwComp conf (DbAccessM conf xs) (MempoolState (ChgAccum conf) rawtx) a
 
-newtype StateTxHandler e ctx rawtx txtype = StateTxHandler
-    { getStateTxHandler :: RwMempoolAct e (TxComponents txtype) ctx rawtx (StateTx txtype)
+newtype StateTxHandler conf rawtx txtype = StateTxHandler
+    { getStateTxHandler :: RwMempoolAct conf (TxComponents txtype) rawtx (StateTx txtype)
     }
 
-type SomeStateTxHandler e ctx c rawtx = SomeData (StateTxHandler e ctx rawtx) c
+type SomeStateTxHandler conf c rawtx = SomeData (StateTxHandler conf rawtx) c
 
-newtype MempoolConfig e ctx c rawtx =
-    MempoolConfig { mcProcessTx :: rawtx -> SomeStateTxHandler e ctx c rawtx }
+newtype MempoolConfig conf c rawtx =
+    MempoolConfig { mcProcessTx :: rawtx -> SomeStateTxHandler conf c rawtx }
 
 data MempoolState chgAccum rawtx = MempoolState
     { msTxs      :: [rawtx]
@@ -77,20 +78,22 @@ instance Default chgAccum => Default (Versioned (MempoolState chgAccum rawtx)) w
     def = Versioned def 0
 
 actionWithMempool
-    :: forall da daa xs chgAccum e rawtx a.
-       ( Show e, Typeable e, Default chgAccum
-       , HasException e StatePException
-       , chgAccum ~ ChgAccum (IOCtx da)
-       , DbActions da daa chgAccum ExecM
-       , ConvertEffect e (IOCtx da) (DbAccessM chgAccum xs) da
-       )
+    :: forall daa xs conf rawtx a chgAccum .
+      ( Show (BException conf), Typeable (BException conf)
+      , Default chgAccum
+      , HasBException conf StatePException
+      , chgAccum ~ ChgAccum conf
+      , DbActions (IOExecEffect conf) daa chgAccum ExecM
+      , ConvertEffect conf (DbAccessM conf xs) (IOExecEffect conf)
+      , Ctx conf ~ IOCtx conf
+      )
     => Mempool chgAccum rawtx
     -> daa ExecM
-    -> RwMempoolAct e xs (IOCtx da) rawtx a
+    -> RwMempoolAct conf xs rawtx a
     -> ExecM a
 actionWithMempool mem@Mempool{..} dbActs callback = do
     Versioned{vsVersion=version,..} <- liftIO $ atomically $ readTVar mempoolState
-    (res, newState) <- runERwCompIO dbActs vsData (convertERwComp convertEffect callback)
+    (res, newState) <- runERwCompIO dbActs vsData (convertERwComp (convertEffect @conf) callback)
     modified <- liftIO $ atomically $ do
         stLast <- readTVar mempoolState
         if version == vsVersion stLast then
@@ -131,28 +134,28 @@ instance (
       ) => MempoolTx txtypes xs txtype
 
 defaultMempoolConfig
-    :: forall e xs ctx (c :: * -> Constraint) txtypes rawtx .
-    ( HasExceptions e [
+    :: forall conf xs (c :: * -> Constraint) txtypes rawtx .
+    ( HasBExceptions conf [
           StatePException
         , CSMappendException
         ]
-    , HasLens ctx (ChgAccumCtx ctx)
+    , HasLens (Ctx conf) (ChgAccumCtx conf)
     )
-    => (rawtx -> SomeData (ProofNExp e ctx rawtx) (Both (MempoolTx txtypes xs) c))
-    -> Validator e ctx txtypes
-    -> MempoolConfig e ctx (Both (MempoolTx txtypes xs) c) rawtx
+    => (rawtx -> SomeData (ProofNExp conf rawtx) (Both (MempoolTx txtypes xs) c))
+    -> Validator conf txtypes
+    -> MempoolConfig conf (Both (MempoolTx txtypes xs) c) rawtx
 defaultMempoolConfig expander validator = MempoolConfig handler
   where
-    handler :: rawtx -> SomeStateTxHandler e ctx (Both (MempoolTx txtypes xs) c) rawtx
+    handler :: rawtx -> SomeStateTxHandler conf (Both (MempoolTx txtypes xs) c) rawtx
     handler rawtx = usingSomeData (expander rawtx) $ SomeData . StateTxHandler . processTx rawtx
 
     processTx
         :: forall txtype . MempoolTx txtypes xs txtype
         => rawtx
-        -> ProofNExp e ctx rawtx txtype
-        -> RwMempoolAct e (TxComponents txtype) ctx rawtx (StateTx txtype)
+        -> ProofNExp conf rawtx txtype
+        -> RwMempoolAct conf (TxComponents txtype) rawtx (StateTx txtype)
     processTx rawtx prfNexp = do
         tx@StateTx{..} <- liftERoComp (expandOneTx prfNexp rawtx)
         liftERoComp $ runValidator validator tx
-        liftERoComp (modifyAccumOne txBody) >>= modify . flip sett
+        liftERoComp (modifyAccumOne @_ @conf txBody) >>= modify . flip sett
         pure tx

--- a/snowdrop-execution/src/Snowdrop/Execution/Mempool/Logic.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/Mempool/Logic.hs
@@ -17,8 +17,8 @@ import           Data.Default (Default (..))
 
 import           Snowdrop.Core (BException, ChgAccum, ChgAccumCtx, Ctx, HasBException,
                                 StatePException, upcastEffERwCompM)
-import           Snowdrop.Execution.Mempool.Core (MempoolConfig (..), MempoolState (..), MempoolTx,
-                                                  RwMempoolAct, StateTxHandler (..), msTxsL)
+import           Snowdrop.Execution.Mempool.Core (MempoolConfig (..), MempoolTx, RwMempoolAct,
+                                                  StateTxHandler (..), msTxsL)
 import           Snowdrop.Util
 
 ---------------------------
@@ -28,7 +28,7 @@ import           Snowdrop.Util
 evictMempool
     :: Default (ChgAccum conf)
     => RwMempoolAct conf xs rawtx [rawtx]
-evictMempool = gets msTxs <* put def
+evictMempool = gets (view msTxsL) <* put def
 
 processTxAndInsertToMempool
     :: ( HasBException conf StatePException

--- a/snowdrop-execution/src/Snowdrop/Execution/Mempool/Logic.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/Mempool/Logic.hs
@@ -15,7 +15,8 @@ import           Control.Lens ((%=))
 import           Control.Monad.Except (catchError)
 import           Data.Default (Default (..))
 
-import           Snowdrop.Core (ChgAccum, ChgAccumCtx, StatePException, upcastEffERwCompM)
+import           Snowdrop.Core (BException, ChgAccum, ChgAccumCtx, Ctx, HasBException,
+                                StatePException, upcastEffERwCompM)
 import           Snowdrop.Execution.Mempool.Core (MempoolConfig (..), MempoolState (..), MempoolTx,
                                                   RwMempoolAct, StateTxHandler (..), msTxsL)
 import           Snowdrop.Util
@@ -25,17 +26,18 @@ import           Snowdrop.Util
 ---------------------------
 
 evictMempool
-    :: Default (ChgAccum ctx)
-    => RwMempoolAct e xs ctx rawtx [rawtx]
+    :: Default (ChgAccum conf)
+    => RwMempoolAct conf xs rawtx [rawtx]
 evictMempool = gets msTxs <* put def
 
 processTxAndInsertToMempool
-    :: ( HasException e StatePException, Show e, Typeable e
-       , HasLens ctx (ChgAccumCtx ctx)
+    :: ( HasBException conf StatePException
+       , Show (BException conf), Typeable (BException conf)
+       , HasLens (Ctx conf) (ChgAccumCtx conf)
        )
-    => MempoolConfig e ctx (Both (MempoolTx txtypes xs) c) rawtx
+    => MempoolConfig conf (Both (MempoolTx txtypes xs) c) rawtx
     -> rawtx
-    -> RwMempoolAct e xs ctx rawtx ()
+    -> RwMempoolAct conf xs rawtx ()
 processTxAndInsertToMempool MempoolConfig{..} rawtx = usingSomeData (mcProcessTx rawtx) $
   \(StateTxHandler handler) -> do
       _tx <- upcastEffERwCompM handler -- expanded tx is not preserved, handler is used only to validate tx
@@ -44,23 +46,24 @@ processTxAndInsertToMempool MempoolConfig{..} rawtx = usingSomeData (mcProcessTx
 newtype Rejected rawtx = Rejected { getRejected :: [rawtx] }
 
 normalizeMempool
-    :: forall e ctx rawtx txtypes xs c .
-       ( HasException e StatePException, Show e, Typeable e
-       , Default (ChgAccum ctx)
-       , HasLens ctx (ChgAccumCtx ctx)
+    :: forall conf rawtx txtypes xs c .
+       ( HasBException conf StatePException
+       , Show (BException conf), Typeable (BException conf)
+       , Default (ChgAccum conf)
+       , HasLens (Ctx conf) (ChgAccumCtx conf)
        )
-    => MempoolConfig e ctx (Both (MempoolTx txtypes xs) c) rawtx
-    -> RwMempoolAct e xs ctx rawtx (Rejected rawtx)
+    => MempoolConfig conf (Both (MempoolTx txtypes xs) c) rawtx
+    -> RwMempoolAct conf xs rawtx (Rejected rawtx)
 normalizeMempool MempoolConfig{..} = do
     txs <- evictMempool
     rejected <- processAll txs
     pure rejected
   where
-    processOne :: rawtx -> RwMempoolAct e xs ctx rawtx ()
+    processOne :: rawtx -> RwMempoolAct conf xs rawtx ()
     processOne rawtx = usingSomeData (mcProcessTx rawtx) $ \(StateTxHandler handler) ->
         void (upcastEffERwCompM handler)
 
-    processAll :: [rawtx] -> RwMempoolAct e xs ctx rawtx (Rejected rawtx)
+    processAll :: [rawtx] -> RwMempoolAct conf xs rawtx (Rejected rawtx)
     processAll txs = fmap (Rejected . fst . partitionEithers) $ do
         forM txs $ \rawtx ->
             (Right <$> processOne rawtx)

--- a/snowdrop-util/src/Snowdrop/Util/Helpers.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Helpers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Rank2Types #-}
 module Snowdrop.Util.Helpers
        (
          VerRes (..)
@@ -9,6 +10,7 @@ module Snowdrop.Util.Helpers
        , PublicKey
        , Signature
        , Signed (..)
+       , HFunctor (..)
        ) where
 
 import           Universum hiding (head, init, last)
@@ -86,3 +88,7 @@ runExceptTV = fmap eitherToVerRes . runExceptT
 -- | Simple helper which is equivallent to expression @\(fa, b) -> (,b) <$> fa@
 propagateSecondF :: Functor f => (f a, b) -> f (a, b)
 propagateSecondF (fa, b) = (,b) <$> fa
+
+-- | Higher-order version of Functor class.
+class HFunctor t where
+    fmapH :: Functor a => (forall x . a x -> b x) -> t a -> t b

--- a/snowdrop-util/src/Snowdrop/Util/Prism/Exception.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Prism/Exception.hs
@@ -2,9 +2,7 @@
 
 module Snowdrop.Util.Prism.Exception
        (
-         HasException
-       , HasExceptions
-       , HasReviews
+         HasReviews
        , HasPrisms
 
        , eitherThrow
@@ -20,13 +18,9 @@ import           Data.Kind (Constraint)
 
 import           Snowdrop.Util.Prism.Class
 
-type HasException e e1 = HasReview e e1
-
 type family HasReviews (e :: *) (exs :: [*]) where
     HasReviews e '[]    = (() :: Constraint)
     HasReviews e (e1:xs) = (HasReview e e1, HasReviews e xs)
-
-type HasExceptions e xs = HasReviews e xs
 
 type family HasPrisms (e :: *) (exs :: [*]) where
     HasPrisms e '[]    = (() :: Constraint)


### PR DESCRIPTION
Twin PR: https://github.com/serokell/snowdrop/pull/121

Refactor code to make `ERoComp` and other types be parametrized by `conf` parameter, from which previous `e`, `ctx`, `chgAccum`, `undo` and some other type parameters are to be derived as type families.

The final purpose of the refactoring is to get rid of hard-coded `SUndo` parameter and allow it to be different depending on storage type (simple storage or AVL+). 