### PR TITLE
[SD-191] Refactor execution toolchain

### DIFF
--- a/snowdrop-block/snowdrop-block.cabal
+++ b/snowdrop-block/snowdrop-block.cabal
@@ -42,6 +42,7 @@ library
       Snowdrop.Block.Types
       Snowdrop.Block.Configuration
       Snowdrop.Block.StateConfiguration
+      Snowdrop.Block.Chain
       Snowdrop.Block.Fork
       Snowdrop.Block.Application
       Snowdrop.Block.State

--- a/snowdrop-block/snowdrop-block.cabal
+++ b/snowdrop-block/snowdrop-block.cabal
@@ -31,6 +31,7 @@ library
     , time
     , hashable-time
     , text-format
+    , vinyl
     , universum >= 1.1.0
   build-tool-depends:
       autoexporter:autoexporter
@@ -47,7 +48,7 @@ library
       Snowdrop.Block.Application
       Snowdrop.Block.State
       Snowdrop.Block.Demo
-      
+
   default-language: Haskell2010
   ghc-options:         -Wall
                        -fno-warn-orphans

--- a/snowdrop-block/src/Snowdrop/Block/Chain.hs
+++ b/snowdrop-block/src/Snowdrop/Block/Chain.hs
@@ -1,0 +1,68 @@
+module Snowdrop.Block.Chain
+       ( iterateChain
+       , wholeChain
+       , forkDepthChain
+       , nDepthChain
+       , nDepthChainNE
+       ) where
+
+import           Universum
+
+import           Snowdrop.Block.Configuration (BlkConfiguration (..), getCurrentBlockRef)
+import           Snowdrop.Block.StateConfiguration (BlkStateConfiguration (..))
+import           Snowdrop.Block.Types (Block (..), BlockHeader, BlockRef, BlockUndo, Blund (..),
+                                       CurrentBlockRef (..), PrevBlockRef (..), RawBlund,
+                                       RawPayload)
+import           Snowdrop.Util (NewestFirst (..), OldestFirst (..), newestFirstFContainer,
+                                toOldestFirst)
+
+-- | Load up to @maxDepth@ blocks from the currently adopted block sequence.
+iterateChain
+    :: forall blkType m .
+    ( Monad m
+    )
+    => BlkStateConfiguration blkType m
+    -> Int -- ^ Max depth of block sequence to load.
+    -> m (NewestFirst [] (RawBlund blkType))
+iterateChain BlkStateConfiguration{..} maxDepth = bscGetTip >>= loadBlock maxDepth
+  where
+    loadBlock
+        :: Int -> Maybe (BlockRef blkType)
+        -> m (NewestFirst [] (RawBlund blkType))
+    loadBlock _ Nothing = pure $ NewestFirst []
+    loadBlock depth (Just blockRef)
+        | depth <= 0 = pure $ NewestFirst []
+        | otherwise = bscGetBlund blockRef >>= \case
+            Nothing -> pure $ NewestFirst [] -- TODO throw exception
+            Just b  -> newestFirstFContainer (b:) <$>
+                loadBlock
+                  (depth - 1)
+                  (unPrevBlockRef . (bcPrevBlockRef bscConfig) . blkHeader . buBlock $ b)
+
+-- | 'wholeChain' retrieves list of Hashes of whole blockchain in oldest first order.
+-- | 'forkDepthChain' retrieves list of Hashes from newest to maxForkDepth in oldest first order.
+wholeChain, forkDepthChain
+    :: Monad m
+    => BlkStateConfiguration blkType m
+    -> m (OldestFirst [] (CurrentBlockRef blkType))
+wholeChain     bsConf = nDepthChain bsConf maxBound
+forkDepthChain bsConf = nDepthChain bsConf $ bcMaxForkDepth $ bscConfig bsConf
+
+nDepthChain
+    :: Monad m
+    => BlkStateConfiguration blkType m
+    -> Int
+    -> m (OldestFirst [] (CurrentBlockRef blkType))
+nDepthChain bsConf depth = toOldestFirst . fmap (getCurrentBlockRef $ bscConfig bsConf) <$> iterateChain bsConf depth
+
+-- | Retrieves 'depth' number of Hashes in oldest first order.
+nDepthChainNE
+    :: Monad m
+    => BlkStateConfiguration blkType m
+    -> Int
+    -> m (Maybe (OldestFirst NonEmpty (Blund (BlockHeader blkType) (RawPayload blkType) (BlockUndo blkType))))
+nDepthChainNE bsConf depth = toOldestFirstNE . toOldestFirst <$> iterateChain bsConf depth
+  where
+    toOldestFirstNE :: OldestFirst [] a -> Maybe (OldestFirst NonEmpty a)
+    toOldestFirstNE (OldestFirst [])       = Nothing
+    toOldestFirstNE (OldestFirst (x : xs)) = Just $ OldestFirst $ (x :| xs)

--- a/snowdrop-block/src/Snowdrop/Block/State.hs
+++ b/snowdrop-block/src/Snowdrop/Block/State.hs
@@ -95,7 +95,6 @@ inmemoryBlkStateConfiguration
         , CSMappendException
         ]
     , Payload blkType ~ [SomeTx c]
-    , Ord (BlockHeader blkType)
     , HasLens (ChgAccum conf) (ChgAccum conf)
     , HasLens (Ctx conf) (ChgAccumCtx conf)
     , HasGetter (RawBlk blkType) [SomeData TxRaw (Both (ExpandableTx txtypes) c)]

--- a/snowdrop-core/src/Snowdrop/Core/Expander.hs
+++ b/snowdrop-core/src/Snowdrop/Core/Expander.hs
@@ -8,7 +8,6 @@ module Snowdrop.Core.Expander
        ( ProofNExp (..)
        , SeqExpander
        , PreExpander (..)
-       , contramapProofNExp
        , contramapSeqExpander
        , contramapPreExpander
        , DiffChangeSet (..)
@@ -26,16 +25,13 @@ import           Data.Vinyl (Rec (..))
 
 import           Snowdrop.Core.ChangeSet (HChangeSet)
 import           Snowdrop.Core.ERoComp (ERoComp)
-import           Snowdrop.Core.Transaction (TxProof)
+import           Snowdrop.Core.Transaction (TxProof, TxRaw)
 
-newtype ProofNExp conf rawTx txtype =
-    ProofNExp (TxProof txtype, SeqExpander conf rawTx txtype)
-
-contramapProofNExp :: (a -> b) -> ProofNExp conf b txtype -> ProofNExp conf a txtype
-contramapProofNExp f (ProofNExp (prf, se)) = ProofNExp (prf, contramapSeqExpander f se)
+newtype ProofNExp conf txtype =
+    ProofNExp (TxRaw txtype -> TxProof txtype, SeqExpander conf txtype)
 
 -- | Sequence of expand stages to be consequently executed upon a given transaction.
-type SeqExpander conf rawTx txtype = Rec (PreExpander conf rawTx) (SeqExpanderComponents txtype)
+type SeqExpander conf txtype = Rec (PreExpander conf (TxRaw txtype)) (SeqExpanderComponents txtype)
 
 contramapSeqExpander :: (a -> b) -> Rec (PreExpander conf b) xs -> Rec (PreExpander conf a) xs
 contramapSeqExpander _ RNil         = RNil

--- a/snowdrop-core/src/Snowdrop/Core/Transaction.hs
+++ b/snowdrop-core/src/Snowdrop/Core/Transaction.hs
@@ -5,6 +5,8 @@
 module Snowdrop.Core.Transaction
        ( TxProof
        , TxComponents
+       , TxRaw (..)
+       , TxRawImpl
 
        , StateTx (..)
        , DownCastableTx
@@ -30,6 +32,10 @@ type family TxProof      (txtype :: k) :: *
 
 -- | Determines components of HChangeSet by txtype.
 type family TxComponents (txtype :: k) :: [*]
+
+type family TxRawImpl (txtype :: k) :: *
+
+newtype TxRaw txtype = TxRaw { unTxRaw :: TxRawImpl txtype }
 
 -- | Transaction which modifies state.
 -- There is also RawTx, which is posted on the blockchain.

--- a/snowdrop-execution/src/Snowdrop/Execution/IOExecutor.hs
+++ b/snowdrop-execution/src/Snowdrop/Execution/IOExecutor.hs
@@ -34,10 +34,10 @@ import qualified Loot.Log.Rio as Rio
 
 import           Snowdrop.Core (BException, BaseM (..), ChgAccum, ChgAccumCtx (..), Ctx,
                                 CtxConcurrently (..), ERwComp, Effectful (..), HasBException,
-                                StatePException, Undo, getCAOrDefault, runERwComp)
+                                StatePException, getCAOrDefault, runERwComp)
 import           Snowdrop.Execution.DbActions (DbAccessActionsU, DbActions (..), DbApplyProof,
                                                DbModifyActions (..))
-import           Snowdrop.Util (ExecM, HasGetter (gett), HasLens (sett), HasReview)
+import           Snowdrop.Util (ExecM, HasGetter (gett), HasLens (sett))
 import qualified Snowdrop.Util as Log
 
 type family IOExecEffect conf :: * -> *
@@ -192,10 +192,8 @@ runERwCompIO daa initS comp = do
     exec = BaseMIOExec $ \(getCAOrDefault . _ctxChgAccum -> chgAccum) dAccess -> executeEffect dAccess daa chgAccum
 
 applyERwComp
-    :: forall stateConf conf a.
+    :: forall conf a.
     ( Default (ChgAccum conf)
-    , HasGetter (Undo conf) (Undo stateConf)
-    , HasReview (Undo conf) (Undo stateConf)
     , Show (BException conf)
     , Typeable (BException conf)
     , HasBException conf StatePException

--- a/snowdrop-util/src/Snowdrop/Util/Helpers.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Helpers.hs
@@ -14,6 +14,7 @@ module Snowdrop.Util.Helpers
        , Sign (..)
        , SecretKey
        , SignKeyPair (..)
+       , SecureHash (..)
        ) where
 
 import           Universum hiding (head, init, last)
@@ -112,3 +113,7 @@ propagateSecondF (fa, b) = (,b) <$> fa
 -- | Higher-order version of Functor class.
 class HFunctor t where
     fmapH :: Functor a => (forall x . a x -> b x) -> t a -> t b
+
+class SecureHash hash msg where
+    secureHash :: msg -> hash
+


### PR DESCRIPTION
Twin PR: https://github.com/serokell/snowdrop/pull/123

Merge not before #35 


What's included (both snowdrop and blockchain-util):

* [x] SD-194 Move block utility functions out of impl
* [x] SD-195 Use Union for raw txs
* [x] SD-200 Move logInfoX out of impl
* [x] SD-157 Move createBlock out of impl
* [x] SD-201 Abstract CLI handling
* [x] SD-156 Factor out `server`, `client`
* [x] SD-206 Abstract `demo` function
