### PR TITLE
[SD-226] Migrate to the latest version of AVL+ library

### DIFF
--- a/snowdrop-dba-avlp/snowdrop-dba-avlp.cabal
+++ b/snowdrop-dba-avlp/snowdrop-dba-avlp.cabal
@@ -37,9 +37,10 @@ library
       Snowdrop.Dba.AVLp
 
   other-modules:
-      Snowdrop.Dba.AVLp.Avl
       Snowdrop.Dba.AVLp.Accum
       Snowdrop.Dba.AVLp.Actions
+      Snowdrop.Dba.AVLp.Avl
+      Snowdrop.Dba.AVLp.Constraints
       Snowdrop.Dba.AVLp.State
 
   default-language:    Haskell2010

--- a/snowdrop-dba-avlp/src/Snowdrop/Dba/AVLp/Constraints.hs
+++ b/snowdrop-dba-avlp/src/Snowdrop/Dba/AVLp/Constraints.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Snowdrop.Dba.AVLp.Constraints where
+
+import qualified Data.Tree.AVL as AVL
+import           Snowdrop.Hetero (HKey, HVal)
+
+class AVL.Hash h (HKey x) (HVal x) => AvlHashC h x
+instance AVL.Hash h (HKey x) (HVal x) => AvlHashC h x

--- a/snowdrop-util/src/Snowdrop/Util/Helpers.hs
+++ b/snowdrop-util/src/Snowdrop/Util/Helpers.hs
@@ -12,6 +12,7 @@ module Snowdrop.Util.Helpers
        , PublicKey
        , Signature
        , Signed (..)
+       , Serialisable (..)
        , HFunctor (..)
        , Sign (..)
        , SecretKey
@@ -144,6 +145,10 @@ runExceptTV = fmap eitherToVerRes . runExceptT
 -- | Simple helper which is equivallent to expression @\(fa, b) -> (,b) <$> fa@
 propagateSecondF :: Functor f => (f a, b) -> f (a, b)
 propagateSecondF (fa, b) = (,b) <$> fa
+
+class Serialisable a where
+    serialise   :: a -> ByteString
+    deserialise :: ByteString -> Either String a
 
 -- | Higher-order version of Functor class.
 class HFunctor t where

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,8 +28,12 @@ extra-deps:
     - code/network
     - code/prelude
 
-- git: https://github.com/serokell/auth-data-structures.git
-  commit: c46d81fac79bbc1e4efcc6c4568a1500b273bd60
+- git: https://github.com/serokell/avl-plus
+  commit: 04377fc71adeaab30e1392f62405ceca40381cb6
+
+# for avl-plus
+- git: git@github.com:serokell/zipp.git
+  commit: 7bf77875305c4b1930b024e21aa6691387c156fc
 
 # Forced by lootbox #
 - base-noprelude-4.10.1.0


### PR DESCRIPTION
Twin PR: https://github.com/serokell/snowdrop/pull/146

Most notable changes here:
+ materialize is no longer possible to implement, since `load` was removed from the public API, instead of materialize it is AVL.showMap for logging, and for proof construction we just remember set of visited nodes returned by AVL.fold
+ KVStoreMonad was split into two typeclasses (KVRetrieve and KVStore)

Planned improvements:
+ remove Sirialisable typeclass, make AVLCache more typesafe by storing values for different components in separate maps
+ reduce usage of AVLCacheT because in many cases it's enough to have only KVRetrieve instance