### PR TITLE
Remove nonsensical cruft from FoldF.

### DIFF
--- a/snowdrop-core/src/Snowdrop/Core/ERoComp/Helpers.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERoComp/Helpers.hs
@@ -88,7 +88,7 @@ iterator
     => b
     -> (b -> (HKey t, HVal t) -> b)
     -> ERoComp conf xs b
-iterator e foldf = effect $ DbIterator @conf @xs @b @t rget (FoldF (e, foldf, id))
+iterator e foldf = effect $ DbIterator @conf @xs @b @t rget (FoldF (e, foldf))
 
 -- | Creates a DbComputeUndo operation.
 computeUndo

--- a/snowdrop-core/src/Snowdrop/Core/ERoComp/Types.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERoComp/Types.hs
@@ -18,8 +18,6 @@ module Snowdrop.Core.ERoComp.Types
 
        , DbAccessU (..)
        , ERoCompU
-
-       , foldFMappend
        ) where
 
 import           Universum
@@ -144,31 +142,11 @@ data DbAccessU (conf :: *) (components :: [*]) (res :: *)
     -- ^ Object for simple access to state (query, iteration)
     -- and change accumulator construction.
 
-deriving instance Functor (DbAccess conf xs)
-deriving instance Functor (DbAccessM conf xs)
-deriving instance Functor (DbAccessU conf xs)
-
--- | FoldF holds functions which are intended to accumulate result of iteratio
+-- | FoldF holds functions which are intended to accumulate result of iteration
 -- over entries.
 -- The first field is an initial value.
 -- The second one is an accumulator.
--- The third one is convertor result of iteration to continuation (a next request to state).
-data FoldF a res = forall b. FoldF (b, b -> a -> b, b -> res)
-
-instance Functor (FoldF a) where
-    fmap f (FoldF (e, foldf, applier)) = FoldF (e, foldf, f . applier)
-
--- | Mappend operation for two @FoldF@s.
-foldFMappend :: (res -> res -> res) -> FoldF a res -> FoldF a res -> FoldF a res
-foldFMappend resMappend (FoldF (e1, f1, applier1)) (FoldF (e2, f2, applier2)) = FoldF (e, f, applier)
-  where
-    e = (e1, e2)
-    f (b1, b2) a = (f1 b1 a, f2 b2 a)
-    applier (b1, b2) = applier1 b1 `resMappend` applier2 b2
-
--- It can't be defined Monoid instance for @FoldF@ because @mempty@ can't be defined.
-instance Semigroup res => Semigroup (FoldF a res) where
-    f1 <> f2 = foldFMappend (<>) f1 f2
+data FoldF a r = FoldF (r, r -> a -> r)
 
 -- | Reader computation which allows you to query for part of bigger state
 -- and build computation considering returned result.

--- a/snowdrop-core/test/Test/Snowdrop/Core/Executor.hs
+++ b/snowdrop-core/test/Test/Snowdrop/Core/Executor.hs
@@ -44,7 +44,7 @@ simpleStateAccessor
     -> DbAccess conf xs res
     -> res
 simpleStateAccessor st (DbQuery q cont) = cont (st `hintersect` q)
-simpleStateAccessor st (DbIterator getComp (FoldF (e, foldf, applier))) = applier $
+simpleStateAccessor st (DbIterator getComp (FoldF (e, foldf))) =
     foldl
       foldf
       e

--- a/snowdrop-dba/src/Snowdrop/Dba/Base/DbActions/Types.hs
+++ b/snowdrop-dba/src/Snowdrop/Dba/Base/DbActions/Types.hs
@@ -121,8 +121,8 @@ instance (chgAccum ~ ChgAccum conf, Monad m, xs ~ DbComponents conf) =>
 
     executeEffect (DbQuery req cont) daa conf =
         cont <$> daaGetter daa conf req
-    executeEffect (DbIterator getComp (FoldF (e, acc, cont))) daa conf =
-        cont <$> ((\record -> runIterAction (getComp record) e acc) =<< daaIter daa conf)
+    executeEffect (DbIterator getComp (FoldF (e, acc))) daa conf =
+        (\record -> runIterAction (getComp record) e acc) =<< daaIter daa conf
 
 instance (chgAccum ~ ChgAccum conf, Monad m, xs ~ DbComponents conf) =>
     DbActions (DbAccessM conf xs) (DbAccessActionsM conf) chgAccum m where


### PR DESCRIPTION
Look at `data FoldF a res = forall b. FoldF (b, b -> a -> b, b -> res)`.

I think this is an utter nonsense — the only possible `forall b . b -> a -> b` function is  `foo x _ = x` (`const`) and things are even worse for `forall b . b -> res` function.