### PR TITLE
[SD-248] Remove `BlockUndo`, `IOExecEffect` type families

### DIFF
--- a/snowdrop-block-exec/src/Snowdrop/Block/Exec/StateConfiguration.hs
+++ b/snowdrop-block-exec/src/Snowdrop/Block/Exec/StateConfiguration.hs
@@ -21,8 +21,8 @@ import           Snowdrop.Block (BlkConfiguration (..), BlkStateConfiguration (.
                                  unCurrentBlockRef)
 import           Snowdrop.Block.Exec.RawTx (CloseBlockRawTx (..), CloseBlockRawTxType,
                                             OpenBlockRawTx (..), OpenBlockRawTxType)
-import           Snowdrop.Block.Exec.Storage (BlockUndo, Blund (..), BlundComponent, TipComponent,
-                                              TipKey (..), TipValue (..))
+import           Snowdrop.Block.Exec.Storage (Blund (..), BlundComponent, TipComponent, TipKey (..),
+                                              TipValue (..))
 import           Snowdrop.Core (CSMappendException (..), ChgAccum, ChgAccumCtx (..), Ctx, ERoCompU,
                                 ExpandableTx, HasBExceptions, QueryERo, SeqExpanders, TxComponents,
                                 TxRaw (..), Undo, UnionSeqExpandersInps, UnionSeqExpandersOuts,
@@ -39,15 +39,15 @@ instance ( RContains txtypes txtype
          , UpCastableERoM (TxComponents txtype) xs
          ) => BlkProcConstr txtypes xs txtype
 
-type BlkProcComponents blkType (txtypes :: [*])
-    = UnionTypes [TipComponent blkType, BlundComponent blkType]
+type BlkProcComponents blkType blkUndo (txtypes :: [*])
+    = UnionTypes [TipComponent blkType, BlundComponent blkType blkUndo]
                  (UnionSeqExpandersOuts txtypes)
 
 -- | An implementation of `BlkStateConfiguration` on top of `ERwComp`.
 -- It uniformly accesses state and block storage (via `DataAccess` interface).
 inmemoryBlkStateConfiguration
-  :: forall blkType txtypes conf openExpRestr closeExpRestr xs c openBlockTxType closeBlockTxType txtypes' .
-    ( xs ~ BlkProcComponents blkType txtypes'
+  :: forall blkType blkUndo txtypes conf openExpRestr closeExpRestr xs c openBlockTxType closeBlockTxType txtypes' .
+    ( xs ~ BlkProcComponents blkType blkUndo txtypes'
     , c ~ Both (ExpandableTx txtypes') (BlkProcConstr txtypes' xs)
     , openBlockTxType ~ OpenBlockRawTxType (BlockHeader blkType) openExpRestr
     , closeBlockTxType ~ CloseBlockRawTxType (BlockHeader blkType) closeExpRestr
@@ -57,12 +57,12 @@ inmemoryBlkStateConfiguration
                            , IterationException (BlockRef blkType)
                            ]
     , NotIntersect '[ openBlockTxType, closeBlockTxType ] txtypes
-    , HasReview (Undo conf) (BlockUndo blkType)
+    , HasReview (Undo conf) blkUndo
     , HasGetter (RawBlk blkType) (BlockHeader blkType)
     , Element (RawBlk blkType) ~ Union TxRaw txtypes
     , Container (RawBlk blkType)
     , HasLens (Ctx conf) (ChgAccumCtx conf)
-    , QueryERo xs (BlundComponent blkType)
+    , QueryERo xs (BlundComponent blkType blkUndo)
     , QueryERo xs (TipComponent blkType)
     , UpCastableERoM (UnionSeqExpandersInps txtypes') xs
     , AllConstrained c txtypes'
@@ -89,7 +89,7 @@ inmemoryBlkStateConfiguration cfg  expander = fix $ \this ->
         let accs = acc0 : (snd <$> txsWithAccs)
         pure $ OldestFirst $ pickElements (NE.zip lengths indicies) accs
     , bscGetHeader = \blockRef -> convertEffect $ do
-        blund <- queryOne @(BlundComponent blkType) @xs @conf $ blockRef
+        blund <- queryOne @(BlundComponent blkType blkUndo) @xs @conf $ blockRef
         pure $ gett . buRawBlk <$> blund
     --  sequentially rollback every block from the tip down to blockRef
     , bscInmemRollback = \acc0 mBlockRef -> do
@@ -98,13 +98,13 @@ inmemoryBlkStateConfiguration cfg  expander = fix $ \this ->
         let refs = unCurrentBlockRef . bcBlockRef cfg . gett . buRawBlk <$> blunds
         fmap (, refs) $ withAccum @conf acc0 $
           modifyAccumUndo @xs @conf $ inj . buUndo <$> blunds
-    , bscBlockExists = convertEffect . queryOneExists @(BlundComponent blkType) @xs @conf
+    , bscBlockExists = convertEffect . queryOneExists @(BlundComponent blkType blkUndo) @xs @conf
     , bscGetTip = unTipValue <<$>> convertEffect (queryOne @(TipComponent blkType) @xs @conf TipKey)
     }
     where
       getBlunds fromRef toRef =
           loadBlocksFromTo
-              (convertEffect . queryOne @(BlundComponent blkType) @xs @conf)
+              (convertEffect . queryOne @(BlundComponent blkType blkUndo) @xs @conf)
               (bcPrevBlockRef cfg . gett @(RawBlk blkType) . buRawBlk)
               (bcMaxForkDepth cfg)
               (Just $ FromRef fromRef)

--- a/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
+++ b/snowdrop-core/src/Snowdrop/Core/ERwComp.hs
@@ -15,9 +15,10 @@ import           Universum
 import           Control.Monad.Except (MonadError)
 
 import           Snowdrop.Core.BaseM (BaseM)
-import           Snowdrop.Core.ERoComp (BException, ChgAccum, ChgAccumCtx (..), ConvertEffect (..),
-                                        Ctx, DbAccessM, HasBException, StatePException (..),
-                                        UpCastableERoM, initAccumCtx, upcastEffERoCompM)
+import           Snowdrop.Core.ERoComp (BException, ChgAccum, ChgAccumCtx, ChgAccumMaybe (..),
+                                        ConvertEffect (..), Ctx, DbAccessM, HasBException,
+                                        StatePException (..), UpCastableERoM, initAccumCtx,
+                                        upcastEffERoCompM)
 import           Snowdrop.Util (HasGetter (..), HasLens (..), throwLocalError)
 
 -- | StateT over ERoComp.
@@ -67,7 +68,7 @@ convertERwComp f (ERwComp (StateT act)) = ERwComp $ StateT $ \s -> f (act s)
 
 upcastEffERwCompM
     :: forall xs supxs conf s a . UpCastableERoM xs supxs
-    => ERwComp conf (DbAccessM conf xs) s a
-    -> ERwComp conf (DbAccessM conf supxs) s a
-upcastEffERwCompM (ERwComp comp) = ERwComp $ StateT $ upcastEffERoCompM . runStateT comp
+    => ERwComp conf (DbAccessM (ChgAccum conf) xs) s a
+    -> ERwComp conf (DbAccessM (ChgAccum conf) supxs) s a
+upcastEffERwCompM (ERwComp comp) = ERwComp $ StateT $ upcastEffERoCompM @_ @_ @conf . runStateT comp
 

--- a/snowdrop-dba/snowdrop-dba.cabal
+++ b/snowdrop-dba/snowdrop-dba.cabal
@@ -31,6 +31,7 @@ library
     , snowdrop-util
     , text-format
     , vinyl
+    , union
   build-tool-depends:
       autoexporter:autoexporter
 
@@ -42,6 +43,7 @@ library
       Snowdrop.Dba.Base.DbActions.Types
       Snowdrop.Dba.Base.DbActions.Composite
       Snowdrop.Dba.Base.IOExecutor
+      Snowdrop.Dba.Base.DefaultConf
 
   default-language:    Haskell2010
 

--- a/snowdrop-dba/src/Snowdrop/Dba/Base/DbActions/Types.hs
+++ b/snowdrop-dba/src/Snowdrop/Dba/Base/DbActions/Types.hs
@@ -117,7 +117,7 @@ class DbActions effect actions param m where
     executeEffect :: effect r -> actions m -> param -> m r
 
 instance (chgAccum ~ ChgAccum conf, Monad m, xs ~ DbComponents conf) =>
-    DbActions (DbAccess conf xs) (DbAccessActions conf) chgAccum m where
+    DbActions (DbAccess xs) (DbAccessActions conf) chgAccum m where
 
     executeEffect (DbQuery req cont) daa conf =
         cont <$> daaGetter daa conf req
@@ -125,14 +125,14 @@ instance (chgAccum ~ ChgAccum conf, Monad m, xs ~ DbComponents conf) =>
         cont <$> ((\record -> runIterAction (getComp record) e acc) =<< daaIter daa conf)
 
 instance (chgAccum ~ ChgAccum conf, Monad m, xs ~ DbComponents conf) =>
-    DbActions (DbAccessM conf xs) (DbAccessActionsM conf) chgAccum m where
+    DbActions (DbAccessM chgAccum xs) (DbAccessActionsM conf) chgAccum m where
 
     executeEffect (DbAccess da) (daaAccess -> daa) conf = executeEffect da daa conf
     executeEffect (DbModifyAccum chgSet cont) daaM conf =
         cont <$> daaModifyAccum daaM conf chgSet
 
-instance (chgAccum ~ ChgAccum conf, Monad m, xs ~ DbComponents conf) =>
-    DbActions (DbAccessU conf xs) (DbAccessActionsU conf) chgAccum m where
+instance (chgAccum ~ ChgAccum conf, undo ~ Undo conf, Monad m, xs ~ DbComponents conf) =>
+    DbActions (DbAccessU undo chgAccum xs) (DbAccessActionsU conf) chgAccum m where
 
     executeEffect (DbAccessM daM) (daaAccessM -> daaM) conf = executeEffect daM daaM conf
     executeEffect (DbComputeUndo cs cont) daaU conf =

--- a/snowdrop-dba/src/Snowdrop/Dba/Base/DefaultConf.hs
+++ b/snowdrop-dba/src/Snowdrop/Dba/Base/DefaultConf.hs
@@ -9,7 +9,6 @@ import           Data.Union (OpenUnion)
 
 import           Snowdrop.Core (BException, ChgAccum, Ctx, Undo)
 import           Snowdrop.Dba.Base.DbActions (DbApplyProof, DbComponents)
-import           Snowdrop.Dba.Base.IOExecutor (IOExecEffect)
 import           Snowdrop.Util (HasReview (..))
 
 
@@ -20,15 +19,14 @@ instance HasReview (OpenUnion es) e => HasReview (Exceptions es) e where
     inj = Exceptions . inj
 instance (Typeable es, Show (OpenUnion es)) => Exception (Exceptions es)
 
-data DefaultConf undo chgAccum (xs :: [*]) applyProof (mkCtx :: * -> *) (ioExecEff :: * -> [*] -> * -> *) (errs :: [*])
+data DefaultConf undo chgAccum (xs :: [*]) applyProof ctx (errs :: [*])
 
--- TODO Remove DbComponents, DbApplyProof, IOExecEffect type families and move to snowdrop-core
+-- TODO Remove DbComponents, DbApplyProof type families and move to snowdrop-core
 
-type instance BException (DefaultConf u c xs ap mc ioe errs) = Exceptions errs
-type instance Undo (DefaultConf undo c xs ap mc ioe e) = undo
-type instance ChgAccum (DefaultConf u chgAccum xs ap mc ioe e) = chgAccum
-type instance DbComponents (DefaultConf u c xs ap mc ioe e) = xs
-type instance DbApplyProof (DefaultConf u c xs applyProof mc ioe e) = applyProof
-type instance Ctx (DefaultConf u c xs ap mkCtx ioe e) = mkCtx (DefaultConf u c xs ap mkCtx ioe e)
-type instance IOExecEffect (DefaultConf u c xs ap mc ioExecEff e) = ioExecEff (DefaultConf u c xs ap mc ioExecEff e) xs
+type instance BException (DefaultConf u c xs ap ctx errs) = Exceptions errs
+type instance Undo (DefaultConf undo c xs ap ctx e) = undo
+type instance ChgAccum (DefaultConf u chgAccum xs ap ctx e) = chgAccum
+type instance DbComponents (DefaultConf u c xs ap ctx e) = xs
+type instance DbApplyProof (DefaultConf u c xs applyProof ctx e) = applyProof
+type instance Ctx (DefaultConf u c xs ap ctx e) = ctx
 

--- a/snowdrop-dba/src/Snowdrop/Dba/Base/DefaultConf.hs
+++ b/snowdrop-dba/src/Snowdrop/Dba/Base/DefaultConf.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs     #-}
+
+module Snowdrop.Dba.Base.DefaultConf where
+
+import           Universum
+
+import           Data.Union (OpenUnion)
+
+import           Snowdrop.Core (BException, ChgAccum, Ctx, Undo)
+import           Snowdrop.Dba.Base.DbActions (DbApplyProof, DbComponents)
+import           Snowdrop.Dba.Base.IOExecutor (IOExecEffect)
+import           Snowdrop.Util (HasReview (..))
+
+
+newtype Exceptions (es :: [*]) = Exceptions (OpenUnion es)
+deriving instance Show (OpenUnion es) => Show (Exceptions es)
+deriving instance Buildable (OpenUnion es) => Buildable (Exceptions es)
+instance HasReview (OpenUnion es) e => HasReview (Exceptions es) e where
+    inj = Exceptions . inj
+instance (Typeable es, Show (OpenUnion es)) => Exception (Exceptions es)
+
+data DefaultConf undo chgAccum (xs :: [*]) applyProof (mkCtx :: * -> *) (ioExecEff :: * -> [*] -> * -> *) (errs :: [*])
+
+-- TODO Remove DbComponents, DbApplyProof, IOExecEffect type families and move to snowdrop-core
+
+type instance BException (DefaultConf u c xs ap mc ioe errs) = Exceptions errs
+type instance Undo (DefaultConf undo c xs ap mc ioe e) = undo
+type instance ChgAccum (DefaultConf u chgAccum xs ap mc ioe e) = chgAccum
+type instance DbComponents (DefaultConf u c xs ap mc ioe e) = xs
+type instance DbApplyProof (DefaultConf u c xs applyProof mc ioe e) = applyProof
+type instance Ctx (DefaultConf u c xs ap mkCtx ioe e) = mkCtx (DefaultConf u c xs ap mkCtx ioe e)
+type instance IOExecEffect (DefaultConf u c xs ap mc ioExecEff e) = ioExecEff (DefaultConf u c xs ap mc ioExecEff e) xs
+

--- a/snowdrop-dba/src/Snowdrop/Dba/Base/IOExecutor.hs
+++ b/snowdrop-dba/src/Snowdrop/Dba/Base/IOExecutor.hs
@@ -5,15 +5,12 @@
 
 module Snowdrop.Dba.Base.IOExecutor
        (
-         IOExecEffect
-       , runBaseMIO
-       , BaseMIOExec (..)
+         BaseMIOExec (..)
        , BaseMIO
        , BaseMException (..)
        , IOCtx (..)
        , runERwCompIO
        , runERoCompIO
-       , applyERwComp
        -- * Lens
        , ctxChgAccum
        , ctxExec
@@ -32,17 +29,14 @@ import           Loot.Base.HasLens (HasLens', lensOf)
 import qualified Loot.Base.HasLens as Loot
 import qualified Loot.Log.Rio as Rio
 
-import           Snowdrop.Core (BException, BaseM (..), ChgAccum, ChgAccumCtx (..), Ctx,
+import           Snowdrop.Core (BException, BaseM (..), ChgAccum, ChgAccumMaybe (..), Ctx,
                                 CtxConcurrently (..), ERwComp, Effectful (..), HasBException,
                                 StatePException, getCAOrDefault, runERwComp)
-import           Snowdrop.Dba.Base.DbActions (DbAccessActionsU, DbActions (..), DbApplyProof,
-                                              DbModifyActions (..))
+import           Snowdrop.Dba.Base.DbActions (DbActions (..))
 import           Snowdrop.Util (ExecM, HasGetter (gett), HasLens (sett))
 import qualified Snowdrop.Util as Log
 
-type family IOExecEffect conf :: * -> *
-
-newtype BaseMIOExec eff ctx = BaseMIOExec { unBaseMIOExec :: forall x . ctx -> eff x -> ExecM x }
+newtype BaseMIOExec eff chgAcc = BaseMIOExec { unBaseMIOExec :: forall x . ChgAccumMaybe chgAcc -> eff x -> ExecM x }
 
 newtype BaseMException e = BaseMException e
     deriving Show
@@ -75,85 +69,71 @@ deriving instance HasLens ctx CtxConcurrently => MonadIO (BaseMIO e eff ctx)
 
 instance (Loot.HasLens' ctx Log.LoggingIO, HasLens ctx CtxConcurrently)
         => Log.MonadLogging (BaseMIO e eff ctx) where
-    log = Rio.defaultLog
-    logName = Rio.defaultLogName
+   log = Rio.defaultLog
+   logName = Rio.defaultLogName
 
 instance (Loot.HasLens' ctx Log.LoggingIO, HasLens ctx CtxConcurrently)
         => Log.ModifyLogName (BaseMIO e eff ctx) where
-    modifyLogNameSel = Rio.defaultModifyLogNameSel
+   modifyLogNameSel = Rio.defaultModifyLogNameSel
 
-instance (HasGetter ctx (BaseMIOExec eff ctx),
-          HasLens ctx CtxConcurrently) => Effectful eff (BaseMIO e eff ctx) where
-    effect eff = BaseMIO $ ReaderT $ \ctx -> unBaseMIOExec (gett ctx) ctx eff
+instance ( HasGetter (IOCtx eff chgAccum) (BaseMIOExec eff chgAccum)
+         , HasLens (IOCtx eff chgAccum) CtxConcurrently
+         , HasGetter (IOCtx eff chgAccum) (ChgAccumMaybe chgAccum)
+         ) => Effectful eff (BaseMIO e eff (IOCtx eff chgAccum)) where
+   effect eff = BaseMIO $ ReaderT $ \ctx -> unBaseMIOExec @_ @chgAccum (gett ctx) (gett ctx) eff
 
 instance (Show e, Typeable e, HasLens ctx CtxConcurrently) => MonadError e (BaseMIO e eff ctx) where
     throwError e = BaseMIO $ throwM $ BaseMException e
     catchError (BaseMIO ma) handler = BaseMIO $
         ma `catch` (\(BaseMException e) -> unBaseMIO $ handler e)
 
-runBaseMIO
-    :: forall e eff ctx a .
-    (
-      Show e, Typeable e, HasGetter ctx (BaseMIOExec eff ctx)
-    , HasLens ctx CtxConcurrently
-    , (Loot.HasLens Log.LoggingIO ctx Log.LoggingIO)
-    )
-    => BaseM e eff ctx a
-    -> ctx
-    -> ExecM a
-runBaseMIO bm ctx = runReaderT (unBaseMIO @e @eff $ unBaseM bm) ctx
-
-data IOCtx conf = IOCtx
-    { _ctxChgAccum   :: ChgAccumCtx conf
-    , _ctxExec       :: BaseMIOExec (IOExecEffect conf) (IOCtx conf)
+data IOCtx effect chgAccum = IOCtx
+    { _ctxChgAccum   :: ChgAccumMaybe chgAccum
+    , _ctxExec       :: BaseMIOExec effect chgAccum
     , _ctxLogger     :: Log.LoggingIO
     , _ctxConcurrent :: CtxConcurrently
     }
 
 makeLenses ''IOCtx
 
-instance Loot.HasLens Log.LoggingIO (IOCtx da) Log.LoggingIO where
+instance Loot.HasLens Log.LoggingIO (IOCtx da chgAcc) Log.LoggingIO where
     lensOf = ctxLogger
 
-instance da ~ IOExecEffect conf => HasLens
-           (IOCtx conf)
-           (BaseMIOExec da (IOCtx conf)) where
+instance HasLens (IOCtx da chgAcc) (BaseMIOExec da chgAcc) where
     sett ctx val = ctx { _ctxExec = val }
 
-instance da ~ IOExecEffect conf => HasGetter
-           (IOCtx conf)
-           (BaseMIOExec da (IOCtx conf)) where
+instance HasGetter (IOCtx da chgAcc) (BaseMIOExec da chgAcc) where
     gett = _ctxExec
 
-instance HasLens (IOCtx conf) (ChgAccumCtx conf) where
+instance HasLens (IOCtx da chgAcc) (ChgAccumMaybe chgAcc) where
     sett ctx val = ctx { _ctxChgAccum = val }
 
-instance HasGetter (IOCtx conf) (ChgAccumCtx conf) where
+instance HasGetter (IOCtx da chgAcc) (ChgAccumMaybe chgAcc) where
     gett = _ctxChgAccum
 
-instance HasLens (IOCtx conf) CtxConcurrently where
+instance HasLens (IOCtx da chgAcc) CtxConcurrently where
     sett ctx val = ctx { _ctxConcurrent = val }
 
-instance HasGetter (IOCtx conf) CtxConcurrently where
+instance HasGetter (IOCtx da chgAcc) CtxConcurrently where
     gett = _ctxConcurrent
 
 runERoCompIO
-  :: forall ctx daa conf m a .
-    ( Show (BException conf)
-    , Typeable (BException conf)
-    , Default (ChgAccum conf)
+  :: forall chgAccum da daa ctx e m a.
+    ( Show e
+    , Typeable e
+    , Default chgAccum
     , MonadIO m
     , MonadReader ctx m
     , HasLens' ctx Log.LoggingIO
-    , DbActions (IOExecEffect conf) daa (ChgAccum conf) ExecM
+    , DbActions da daa chgAccum ExecM
     )
     => daa ExecM
-    -> Maybe (ChgAccum conf)
-    -> BaseM (BException conf) (IOExecEffect conf) (IOCtx conf) a
+    -> Maybe chgAccum
+    -> BaseM e da (IOCtx da chgAccum) a
     -> m a
 runERoCompIO daa initAcc comp = do
     logger <- view (lensOf @Log.LoggingIO)
-    liftIO $ Log.runRIO logger $ runBaseMIO comp $
+    liftIO $ Log.runRIO logger $ runReaderT (unBaseMIO @_ @da (unBaseM comp))
         IOCtx
           { _ctxChgAccum = maybe CANotInitialized CAInitialized initAcc
           , _ctxExec = exec
@@ -161,10 +141,10 @@ runERoCompIO daa initAcc comp = do
           , _ctxConcurrent = def
           }
   where
-    exec = BaseMIOExec $ \(getCAOrDefault . _ctxChgAccum -> chgAccum) da -> executeEffect da daa chgAccum
+    exec = BaseMIOExec @_ @chgAccum $ \(getCAOrDefault -> chgAccum) da -> executeEffect da daa chgAccum
 
 runERwCompIO
-  :: forall ctx daa s conf m a .
+  :: forall s conf da daa ctx m a.
     ( Show (BException conf)
     , Typeable (BException conf)
     , Default (ChgAccum conf)
@@ -172,16 +152,16 @@ runERwCompIO
     , MonadIO m
     , MonadReader ctx m
     , HasLens' ctx Log.LoggingIO
-    , DbActions (IOExecEffect conf) daa (ChgAccum conf) ExecM
-    , Ctx conf ~ IOCtx conf
+    , DbActions da daa (ChgAccum conf) ExecM
+    , Ctx conf ~ IOCtx da (ChgAccum conf)
     )
     => daa ExecM
     -> s
-    -> ERwComp conf (IOExecEffect conf) s a
+    -> ERwComp conf da s a
     -> m (a, s)
 runERwCompIO daa initS comp = do
     logger <- view (lensOf @Log.LoggingIO)
-    liftIO $ Log.runRIO logger $ runBaseMIO (runERwComp comp initS) $
+    liftIO $ Log.runRIO logger $ runReaderT (unBaseMIO @_ @da $ unBaseM $ runERwComp comp initS) $
         IOCtx
           { _ctxChgAccum = CANotInitialized
           , _ctxExec = exec
@@ -189,20 +169,4 @@ runERwCompIO daa initS comp = do
           , _ctxConcurrent = def
           }
   where
-    exec = BaseMIOExec $ \(getCAOrDefault . _ctxChgAccum -> chgAccum) dAccess -> executeEffect dAccess daa chgAccum
-
-applyERwComp
-    :: forall conf a.
-    ( Default (ChgAccum conf)
-    , Show (BException conf)
-    , Typeable (BException conf)
-    , HasBException conf StatePException
-    , Ctx conf ~ IOCtx conf
-    , DbActions (IOExecEffect conf) (DbAccessActionsU conf) (ChgAccum conf) ExecM
-    )
-    => DbModifyActions conf ExecM
-    -> ERwComp conf (IOExecEffect conf) (ChgAccum conf) a
-    -> ExecM (a, DbApplyProof conf)
-applyERwComp dma rwComp = do
-    (a, cs) <- runERwCompIO (dmaAccess dma) def rwComp
-    (a,) <$> dmaApply dma cs
+    exec = BaseMIOExec $ \(getCAOrDefault -> chgAccum) dAccess -> executeEffect dAccess daa chgAccum

--- a/snowdrop-mempool/src/Snowdrop/Mempool/Core.hs
+++ b/snowdrop-mempool/src/Snowdrop/Mempool/Core.hs
@@ -30,7 +30,7 @@ import           Snowdrop.Core (BException, CSMappendException, ChgAccum, ChgAcc
                                 StatePException, StateTx (..), TxComponents, TxRaw, UpCastableERoM,
                                 convertERwComp, convertEffect, expandOneTx, liftERoComp,
                                 modifyAccumOne)
-import           Snowdrop.Dba.Base (DbActions, IOCtx, IOExecEffect, runERwCompIO)
+import           Snowdrop.Dba.Base (DbActions, IOCtx, runERwCompIO)
 import           Snowdrop.Hetero (Both, RContains, SomeData (..), usingSomeData)
 import           Snowdrop.Util (ExecM, HasGetter (..), HasLens (..))
 
@@ -39,7 +39,7 @@ import           Snowdrop.Util (ExecM, HasGetter (..), HasLens (..))
 ---------------------------
 
 type RwMempoolAct conf xs rawtx a =
-    ERwComp conf (DbAccessM conf xs) (MempoolState conf rawtx) a
+    ERwComp conf (DbAccessM (ChgAccum conf) xs) (MempoolState conf rawtx) a
 
 newtype StateTxHandler conf rawtx txtype = StateTxHandler
     { getStateTxHandler :: RwMempoolAct conf (TxComponents txtype) rawtx (StateTx txtype)
@@ -83,14 +83,14 @@ instance Default chgAccum => Default (Versioned (MempoolState' chgAccum rawtx)) 
     def = Versioned def 0
 
 actionWithMempool
-    :: forall daa xs conf rawtx a chgAccum .
+    ::
       ( Show (BException conf), Typeable (BException conf)
       , Default chgAccum
       , HasBException conf StatePException
       , chgAccum ~ ChgAccum conf
-      , DbActions (IOExecEffect conf) daa chgAccum ExecM
-      , ConvertEffect (DbAccessM conf xs) (IOExecEffect conf)
-      , Ctx conf ~ IOCtx conf
+      , DbActions da daa chgAccum ExecM
+      , ConvertEffect (DbAccessM (ChgAccum conf) xs) da
+      , Ctx conf ~ IOCtx da chgAccum
       )
     => Mempool conf rawtx
     -> daa ExecM
@@ -165,5 +165,5 @@ defaultMempoolConfig exps = MempoolConfig handler
     processTx rawtx = do
         let exd = unSeqExp $ rget @txtype exps
         tx@StateTx{..} <- liftERoComp (expandOneTx exd rawtx)
-        liftERoComp (modifyAccumOne @_ @conf txBody) >>= modify . flip sett
+        liftERoComp (modifyAccumOne @conf txBody) >>= modify . flip sett
         pure tx


### PR DESCRIPTION
Twin PR: https://github.com/serokell/snowdrop/pull/144